### PR TITLE
refactor(otel): add old SetSpanAttributesFromStruct function for direct struct-to-span attribute conversion

### DIFF
--- a/commons/opentelemetry/otel.go
+++ b/commons/opentelemetry/otel.go
@@ -218,6 +218,23 @@ func (tl *Telemetry) InitializeTelemetry(logger log.Logger) *Telemetry {
 	}
 }
 
+// SetSpanAttributesFromStruct converts a struct to a JSON string and sets it as an attribute on the span.
+func SetSpanAttributesFromStruct(span *trace.Span, key string, valueStruct any) error {
+	jsonByte, err := json.Marshal(valueStruct)
+	if err != nil {
+		return err
+	}
+
+	vStr := string(jsonByte)
+
+	(*span).SetAttributes(attribute.KeyValue{
+		Key:   attribute.Key(key),
+		Value: attribute.StringValue(vStr),
+	})
+
+	return nil
+}
+
 // SetSpanAttributesFromStructWithObfuscation converts a struct to a JSON string,
 // obfuscates sensitive fields using the default obfuscator, and sets it as an attribute on the span.
 func SetSpanAttributesFromStructWithObfuscation(span *trace.Span, key string, valueStruct any) error {


### PR DESCRIPTION
# Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Feature
- [ ] Fix
- [x] Refactor
- [ ] Pipeline
- [ ] Tests
- [ ] Documentation

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
## Obs: Please, always remember to target your PR to develop branch instead of main.

---

This pull request introduces a new helper function, `SetSpanAttributesFromStruct`, in the `commons/opentelemetry/otel.go` file of the LerianStudio/lib-commons repository. The function is designed to serialize a given struct into a JSON string and add it as an attribute to an OpenTelemetry span, thereby simplifying the process of attaching complex data structures to traces. The changes are being merged from the `refactor/add-old-add-attributes-span-method` branch into the `develop` branch.