### PR TITLE
refactor: use constants for rate limit header names instead of hardcoded strings

### DIFF
--- a/commons/constants/headers.go
+++ b/commons/constants/headers.go
@@ -17,4 +17,9 @@ const (
 	Basic               = "Basic"
 	BasicAuth           = "Basic Auth"
 	WWWAuthenticate     = "WWW-Authenticate"
+
+	// Rate Limit Headers
+	RateLimitLimit     = "X-RateLimit-Limit"
+	RateLimitRemaining = "X-RateLimit-Remaining"
+	RateLimitReset     = "X-RateLimit-Reset"
 )

--- a/commons/net/http/withRateLimit.go
+++ b/commons/net/http/withRateLimit.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 
+	cn "github.com/LerianStudio/lib-commons/v2/commons/constants"
 	"github.com/LerianStudio/lib-commons/v2/commons/net/http/ratelimit"
 	"github.com/gofiber/fiber/v2"
 )
@@ -196,9 +197,9 @@ func handleRateLimitExceeded(c *fiber.Ctx, config RateLimitConfig, key string, r
 // - X-RateLimit-Remaining: Requests remaining in current window
 // - X-RateLimit-Reset: Unix timestamp when the window resets
 func setRateLimitHeaders(c *fiber.Ctx, result *ratelimit.Result) {
-	c.Set("X-RateLimit-Limit", fmt.Sprintf("%d", result.Limit))
-	c.Set("X-RateLimit-Remaining", fmt.Sprintf("%d", result.Remaining))
-	c.Set("X-RateLimit-Reset", fmt.Sprintf("%d", result.ResetAt.Unix()))
+	c.Set(cn.RateLimitLimit, fmt.Sprintf("%d", result.Limit))
+	c.Set(cn.RateLimitRemaining, fmt.Sprintf("%d", result.Remaining))
+	c.Set(cn.RateLimitReset, fmt.Sprintf("%d", result.ResetAt.Unix()))
 }
 
 // shouldSkipPath checks if a path should bypass rate limiting.


### PR DESCRIPTION
# Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Feature
- [ ] Fix
- [x] Refactor
- [ ] Pipeline
- [ ] Tests
- [ ] Documentation

## Checklist
Please check each item after it's completed.

- [ ] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [ ] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [ ] I have confirmed this code is ready for review.

## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
## Obs: Please, always remember to target your PR to develop branch instead of main.

---

<!-- kody-pr-summary:start -->
Refactors the rate limit header management by introducing dedicated constants for "X-RateLimit-Limit", "X-RateLimit-Remaining", and "X-RateLimit-Reset" header names in `commons/constants/headers.go`. These new constants are then used in the `setRateLimitHeaders` function within `commons/net/http/withRateLimit.go`, replacing the previously hardcoded string literals. This change improves maintainability and consistency by centralizing the definition of rate limit header names.
<!-- kody-pr-summary:end -->