### PR TITLE
feat: support configurable MultiStatementEnabled for PostgreSQL migrations

### DIFF
--- a/commons/postgres/postgres.go
+++ b/commons/postgres/postgres.go
@@ -39,6 +39,16 @@ type PostgresConnection struct {
 	MultiStatementEnabled *bool
 }
 
+// resolveMultiStatementEnabled returns the resolved value of MultiStatementEnabled.
+// Returns true if MultiStatementEnabled is nil (backward compatible default),
+// otherwise returns the dereferenced value.
+func (pc *PostgresConnection) resolveMultiStatementEnabled() bool {
+	if pc.MultiStatementEnabled != nil {
+		return *pc.MultiStatementEnabled
+	}
+	return true
+}
+
 // Connect keeps a singleton connection with postgres.
 func (pc *PostgresConnection) Connect() error {
 	pc.Logger.Info("Connecting to primary and replica databases...")
@@ -83,14 +93,8 @@ func (pc *PostgresConnection) Connect() error {
 
 	primaryURL.Scheme = "file"
 
-	// Resolve MultiStatementEnabled with default true for backward compatibility
-	multiStmtEnabled := true
-	if pc.MultiStatementEnabled != nil {
-		multiStmtEnabled = *pc.MultiStatementEnabled
-	}
-
 	primaryDriver, err := postgres.WithInstance(dbPrimary, &postgres.Config{
-		MultiStatementEnabled: multiStmtEnabled,
+		MultiStatementEnabled: pc.resolveMultiStatementEnabled(),
 		DatabaseName:          pc.PrimaryDBName,
 		SchemaName:            "public",
 	})

--- a/commons/postgres/postgres.go
+++ b/commons/postgres/postgres.go
@@ -46,6 +46,7 @@ func (pc *PostgresConnection) resolveMultiStatementEnabled() bool {
 	if pc.MultiStatementEnabled != nil {
 		return *pc.MultiStatementEnabled
 	}
+
 	return true
 }
 

--- a/commons/postgres/postgres.go
+++ b/commons/postgres/postgres.go
@@ -33,6 +33,10 @@ type PostgresConnection struct {
 	Logger                  log.Logger
 	MaxOpenConnections      int
 	MaxIdleConnections      int
+	// MultiStatementEnabled controls whether migrations run with multi-statement mode.
+	// When nil, defaults to true for backward compatibility.
+	// Use pointers.Bool(true) or pointers.Bool(false) to set explicitly.
+	MultiStatementEnabled *bool
 }
 
 // Connect keeps a singleton connection with postgres.
@@ -79,8 +83,14 @@ func (pc *PostgresConnection) Connect() error {
 
 	primaryURL.Scheme = "file"
 
+	// Resolve MultiStatementEnabled with default true for backward compatibility
+	multiStmtEnabled := true
+	if pc.MultiStatementEnabled != nil {
+		multiStmtEnabled = *pc.MultiStatementEnabled
+	}
+
 	primaryDriver, err := postgres.WithInstance(dbPrimary, &postgres.Config{
-		MultiStatementEnabled: true,
+		MultiStatementEnabled: multiStmtEnabled,
 		DatabaseName:          pc.PrimaryDBName,
 		SchemaName:            "public",
 	})

--- a/commons/postgres/postgres_test.go
+++ b/commons/postgres/postgres_test.go
@@ -1,0 +1,167 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/LerianStudio/lib-commons/v2/commons/log"
+	"github.com/LerianStudio/lib-commons/v2/commons/pointers"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockLogger implements log.Logger interface for testing
+type mockLogger struct{}
+
+func (l *mockLogger) Debug(args ...any)                                 {}
+func (l *mockLogger) Debugf(format string, args ...any)                 {}
+func (l *mockLogger) Debugln(args ...any)                               {}
+func (l *mockLogger) Info(args ...any)                                  {}
+func (l *mockLogger) Infof(format string, args ...any)                  {}
+func (l *mockLogger) Infoln(args ...any)                                {}
+func (l *mockLogger) Warn(args ...any)                                  {}
+func (l *mockLogger) Warnf(format string, args ...any)                  {}
+func (l *mockLogger) Warnln(args ...any)                                {}
+func (l *mockLogger) Error(args ...any)                                 {}
+func (l *mockLogger) Errorf(format string, args ...any)                 {}
+func (l *mockLogger) Errorln(args ...any)                               {}
+func (l *mockLogger) Fatal(args ...any)                                 {}
+func (l *mockLogger) Fatalf(format string, args ...any)                 {}
+func (l *mockLogger) Fatalln(args ...any)                               {}
+func (l *mockLogger) WithFields(fields ...any) log.Logger               { return l }
+func (l *mockLogger) WithDefaultMessageTemplate(msg string) log.Logger  { return l }
+func (l *mockLogger) Sync() error                                       { return nil }
+
+func TestPostgresConnection_MultiStatementEnabled_Nil_DefaultsToTrue(t *testing.T) {
+	t.Parallel()
+
+	pc := &PostgresConnection{
+		ConnectionStringPrimary: "postgres://user:pass@localhost:5432/testdb",
+		ConnectionStringReplica: "postgres://user:pass@localhost:5432/testdb",
+		PrimaryDBName:           "testdb",
+		ReplicaDBName:           "testdb",
+		Logger:                  &mockLogger{},
+		MaxOpenConnections:      10,
+		MaxIdleConnections:      5,
+		MultiStatementEnabled:   nil, // explicitly nil to test default
+	}
+
+	// Verify the field is nil
+	assert.Nil(t, pc.MultiStatementEnabled, "MultiStatementEnabled should be nil by default")
+
+	// Verify default resolution logic (simulating what Connect() does)
+	multiStmtEnabled := true
+	if pc.MultiStatementEnabled != nil {
+		multiStmtEnabled = *pc.MultiStatementEnabled
+	}
+
+	assert.True(t, multiStmtEnabled, "nil MultiStatementEnabled should resolve to true")
+}
+
+func TestPostgresConnection_MultiStatementEnabled_ExplicitTrue(t *testing.T) {
+	t.Parallel()
+
+	pc := &PostgresConnection{
+		ConnectionStringPrimary: "postgres://user:pass@localhost:5432/testdb",
+		ConnectionStringReplica: "postgres://user:pass@localhost:5432/testdb",
+		PrimaryDBName:           "testdb",
+		ReplicaDBName:           "testdb",
+		Logger:                  &mockLogger{},
+		MaxOpenConnections:      10,
+		MaxIdleConnections:      5,
+		MultiStatementEnabled:   pointers.Bool(true), // explicitly true
+	}
+
+	// Verify the field is set to true
+	assert.NotNil(t, pc.MultiStatementEnabled, "MultiStatementEnabled should not be nil")
+	assert.True(t, *pc.MultiStatementEnabled, "MultiStatementEnabled should be true")
+
+	// Verify resolution logic
+	multiStmtEnabled := true
+	if pc.MultiStatementEnabled != nil {
+		multiStmtEnabled = *pc.MultiStatementEnabled
+	}
+
+	assert.True(t, multiStmtEnabled, "explicit true should resolve to true")
+}
+
+func TestPostgresConnection_MultiStatementEnabled_ExplicitFalse(t *testing.T) {
+	t.Parallel()
+
+	pc := &PostgresConnection{
+		ConnectionStringPrimary: "postgres://user:pass@localhost:5432/testdb",
+		ConnectionStringReplica: "postgres://user:pass@localhost:5432/testdb",
+		PrimaryDBName:           "testdb",
+		ReplicaDBName:           "testdb",
+		Logger:                  &mockLogger{},
+		MaxOpenConnections:      10,
+		MaxIdleConnections:      5,
+		MultiStatementEnabled:   pointers.Bool(false), // explicitly false
+	}
+
+	// Verify the field is set to false
+	assert.NotNil(t, pc.MultiStatementEnabled, "MultiStatementEnabled should not be nil")
+	assert.False(t, *pc.MultiStatementEnabled, "MultiStatementEnabled should be false")
+
+	// Verify resolution logic
+	multiStmtEnabled := true
+	if pc.MultiStatementEnabled != nil {
+		multiStmtEnabled = *pc.MultiStatementEnabled
+	}
+
+	assert.False(t, multiStmtEnabled, "explicit false should resolve to false")
+}
+
+func TestPostgresConnection_MultiStatementEnabled_AllCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		multiStatementEnabled *bool
+		expectedResolved      bool
+		description           string
+	}{
+		{
+			name:                  "nil_defaults_to_true",
+			multiStatementEnabled: nil,
+			expectedResolved:      true,
+			description:           "backward compatibility - nil should default to true",
+		},
+		{
+			name:                  "explicit_true",
+			multiStatementEnabled: pointers.Bool(true),
+			expectedResolved:      true,
+			description:           "explicit true should resolve to true",
+		},
+		{
+			name:                  "explicit_false",
+			multiStatementEnabled: pointers.Bool(false),
+			expectedResolved:      false,
+			description:           "explicit false should resolve to false",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pc := &PostgresConnection{
+				ConnectionStringPrimary: "postgres://user:pass@localhost:5432/testdb",
+				ConnectionStringReplica: "postgres://user:pass@localhost:5432/testdb",
+				PrimaryDBName:           "testdb",
+				ReplicaDBName:           "testdb",
+				Logger:                  &mockLogger{},
+				MaxOpenConnections:      10,
+				MaxIdleConnections:      5,
+				MultiStatementEnabled:   tt.multiStatementEnabled,
+			}
+
+			// Simulate the resolution logic from Connect()
+			multiStmtEnabled := true
+			if pc.MultiStatementEnabled != nil {
+				multiStmtEnabled = *pc.MultiStatementEnabled
+			}
+
+			assert.Equal(t, tt.expectedResolved, multiStmtEnabled, tt.description)
+		})
+	}
+}

--- a/commons/postgres/postgres_test.go
+++ b/commons/postgres/postgres_test.go
@@ -47,13 +47,8 @@ func TestPostgresConnection_MultiStatementEnabled_Nil_DefaultsToTrue(t *testing.
 	// Verify the field is nil
 	assert.Nil(t, pc.MultiStatementEnabled, "MultiStatementEnabled should be nil by default")
 
-	// Verify default resolution logic (simulating what Connect() does)
-	multiStmtEnabled := true
-	if pc.MultiStatementEnabled != nil {
-		multiStmtEnabled = *pc.MultiStatementEnabled
-	}
-
-	assert.True(t, multiStmtEnabled, "nil MultiStatementEnabled should resolve to true")
+	// Verify default resolution logic (using helper method from Connect())
+	assert.True(t, pc.resolveMultiStatementEnabled(), "nil MultiStatementEnabled should resolve to true")
 }
 
 func TestPostgresConnection_MultiStatementEnabled_ExplicitTrue(t *testing.T) {
@@ -74,13 +69,8 @@ func TestPostgresConnection_MultiStatementEnabled_ExplicitTrue(t *testing.T) {
 	assert.NotNil(t, pc.MultiStatementEnabled, "MultiStatementEnabled should not be nil")
 	assert.True(t, *pc.MultiStatementEnabled, "MultiStatementEnabled should be true")
 
-	// Verify resolution logic
-	multiStmtEnabled := true
-	if pc.MultiStatementEnabled != nil {
-		multiStmtEnabled = *pc.MultiStatementEnabled
-	}
-
-	assert.True(t, multiStmtEnabled, "explicit true should resolve to true")
+	// Verify resolution logic (using helper method from Connect())
+	assert.True(t, pc.resolveMultiStatementEnabled(), "explicit true should resolve to true")
 }
 
 func TestPostgresConnection_MultiStatementEnabled_ExplicitFalse(t *testing.T) {
@@ -101,13 +91,8 @@ func TestPostgresConnection_MultiStatementEnabled_ExplicitFalse(t *testing.T) {
 	assert.NotNil(t, pc.MultiStatementEnabled, "MultiStatementEnabled should not be nil")
 	assert.False(t, *pc.MultiStatementEnabled, "MultiStatementEnabled should be false")
 
-	// Verify resolution logic
-	multiStmtEnabled := true
-	if pc.MultiStatementEnabled != nil {
-		multiStmtEnabled = *pc.MultiStatementEnabled
-	}
-
-	assert.False(t, multiStmtEnabled, "explicit false should resolve to false")
+	// Verify resolution logic (using helper method from Connect())
+	assert.False(t, pc.resolveMultiStatementEnabled(), "explicit false should resolve to false")
 }
 
 func TestPostgresConnection_MultiStatementEnabled_AllCases(t *testing.T) {
@@ -140,7 +125,6 @@ func TestPostgresConnection_MultiStatementEnabled_AllCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -155,13 +139,8 @@ func TestPostgresConnection_MultiStatementEnabled_AllCases(t *testing.T) {
 				MultiStatementEnabled:   tt.multiStatementEnabled,
 			}
 
-			// Simulate the resolution logic from Connect()
-			multiStmtEnabled := true
-			if pc.MultiStatementEnabled != nil {
-				multiStmtEnabled = *pc.MultiStatementEnabled
-			}
-
-			assert.Equal(t, tt.expectedResolved, multiStmtEnabled, tt.description)
+			// Use the same resolution logic as Connect()
+			assert.Equal(t, tt.expectedResolved, pc.resolveMultiStatementEnabled(), tt.description)
 		})
 	}
 }


### PR DESCRIPTION
## Code Changes

### Modified: commons/postgres/postgres.go (+10 lines)
- Added `MultiStatementEnabled *bool` field to struct
- Added resolution logic in Connect() method

### Created: commons/postgres/postgres_test.go (NEW - 167 lines)
- mockLogger implementation
- 4 test functions with 7 total test cases

## Test Results
- ✅ 7/7 tests pass (100% pass rate)
- ✅ Build successful (no errors)