### PR TITLE
feat: implement rabbit EnsureChannelWithContext with timeout support

### DIFF
--- a/commons/rabbitmq/rabbitmq.go
+++ b/commons/rabbitmq/rabbitmq.go
@@ -1,6 +1,7 @@
 package rabbitmq
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,11 +11,16 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/LerianStudio/lib-commons/v2/commons/log"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"go.uber.org/zap"
 )
+
+// DefaultConnectionTimeout is the default timeout for establishing RabbitMQ connections
+// when ConnectionTimeout field is not set.
+const DefaultConnectionTimeout = 30 * time.Second
 
 // RabbitMQConnection is a hub which deal with rabbitmq connections.
 type RabbitMQConnection struct {
@@ -31,6 +37,7 @@ type RabbitMQConnection struct {
 	Channel                *amqp.Channel
 	Logger                 log.Logger
 	Connected              bool
+	ConnectionTimeout      time.Duration // timeout for establishing connection. Zero value uses default of 30s.
 }
 
 // Connect keeps a singleton connection with rabbitmq.
@@ -80,6 +87,7 @@ func (rc *RabbitMQConnection) Connect() error {
 }
 
 // EnsureChannel ensures that the channel is open and connected.
+// For context-aware connection handling with timeout support, see EnsureChannelWithContext.
 func (rc *RabbitMQConnection) EnsureChannel() error {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
@@ -89,9 +97,9 @@ func (rc *RabbitMQConnection) EnsureChannel() error {
 	if rc.Connection == nil || rc.Connection.IsClosed() {
 		conn, err := amqp.Dial(rc.ConnectionStringSource)
 		if err != nil {
-			rc.Logger.Errorf("can't connect to rabbitmq: %v", err)
+			rc.Logger.Error("failed to connect to rabbitmq", zap.Error(err))
 
-			return err
+			return fmt.Errorf("failed to connect to rabbitmq: %w", err)
 		}
 
 		rc.Connection = conn
@@ -110,9 +118,9 @@ func (rc *RabbitMQConnection) EnsureChannel() error {
 				rc.Connection = nil
 			}
 
-			rc.Logger.Errorf("can't open channel on rabbitmq: %v", err)
+			rc.Logger.Error("failed to open channel on rabbitmq", zap.Error(err))
 
-			return err
+			return fmt.Errorf("failed to open channel on rabbitmq: %w", err)
 		}
 
 		rc.Channel = ch
@@ -121,6 +129,124 @@ func (rc *RabbitMQConnection) EnsureChannel() error {
 	rc.Connected = true
 
 	return nil
+}
+
+// EnsureChannelWithContext ensures that the channel is open and connected,
+// respecting context cancellation and deadline. Unlike EnsureChannel, this method
+// will return immediately if context is cancelled or deadline exceeded.
+//
+// The effective connection timeout is the minimum of:
+//   - The remaining time until context deadline (if context has a deadline)
+//   - ConnectionTimeout field value (defaults to 30s if zero)
+//
+// Usage:
+//
+//	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+//	defer cancel()
+//	if err := conn.EnsureChannelWithContext(ctx); err != nil {
+//	    // Handle error - could be context timeout or connection failure
+//	}
+func (rc *RabbitMQConnection) EnsureChannelWithContext(ctx context.Context) error {
+	// Check context before acquiring lock to fail fast
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	// Check context again after acquiring lock
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	newConnection := false
+
+	if rc.Connection == nil || rc.Connection.IsClosed() {
+		conn, err := rc.dialWithContext(ctx)
+		if err != nil {
+			rc.Logger.Error("failed to connect to rabbitmq", zap.Error(err))
+			return fmt.Errorf("failed to connect to rabbitmq: %w", err)
+		}
+
+		rc.Connection = conn
+		newConnection = true
+	}
+
+	if rc.Channel == nil || rc.Channel.IsClosed() {
+		ch, err := rc.Connection.Channel()
+		if err != nil {
+			// cleanup connection if we just created it and channel creation fails
+			if newConnection {
+				if closeErr := rc.Connection.Close(); closeErr != nil {
+					rc.Logger.Warn("failed to close connection during cleanup", zap.Error(closeErr))
+				}
+
+				rc.Connection = nil
+			}
+
+			rc.Logger.Error("failed to open channel on rabbitmq", zap.Error(err))
+
+			return fmt.Errorf("failed to open channel on rabbitmq: %w", err)
+		}
+
+		rc.Channel = ch
+	}
+
+	rc.Connected = true
+
+	return nil
+}
+
+// dialWithContext creates an AMQP connection with context awareness.
+// It extracts the deadline from context and uses it as connection timeout.
+// If context has no deadline, uses ConnectionTimeout field (default 30s).
+func (rc *RabbitMQConnection) dialWithContext(ctx context.Context) (*amqp.Connection, error) {
+	// Determine timeout from context deadline or default
+	timeout := rc.ConnectionTimeout
+	if timeout == 0 {
+		timeout = DefaultConnectionTimeout
+	}
+
+	if deadline, ok := ctx.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, context.DeadlineExceeded
+		}
+
+		if remaining < timeout {
+			timeout = remaining
+		}
+	}
+
+	// Create config with custom dialer that respects timeout
+	config := amqp.Config{
+		Dial: func(network, addr string) (net.Conn, error) {
+			// Check context before dialing
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+
+			dialer := &net.Dialer{
+				Timeout: timeout,
+			}
+
+			conn, err := dialer.DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+
+			return conn, nil
+		},
+	}
+
+	return amqp.DialConfig(rc.ConnectionStringSource, config)
 }
 
 // GetNewConnect returns a pointer to the rabbitmq connection, initializing it if necessary.

--- a/commons/rabbitmq/rabbitmq.go
+++ b/commons/rabbitmq/rabbitmq.go
@@ -118,6 +118,10 @@ func (rc *RabbitMQConnection) EnsureChannel() error {
 				rc.Connection = nil
 			}
 
+			// Reset stale state so GetNewConnect triggers reconnection
+			rc.Connected = false
+			rc.Channel = nil
+
 			rc.Logger.Error("failed to open channel on rabbitmq", zap.Error(err))
 
 			return fmt.Errorf("failed to open channel on rabbitmq: %w", err)
@@ -188,6 +192,10 @@ func (rc *RabbitMQConnection) EnsureChannelWithContext(ctx context.Context) erro
 
 				rc.Connection = nil
 			}
+
+			// Reset stale state so GetNewConnect triggers reconnection
+			rc.Connected = false
+			rc.Channel = nil
 
 			rc.Logger.Error("failed to open channel on rabbitmq", zap.Error(err))
 

--- a/commons/rabbitmq/rabbitmq_test.go
+++ b/commons/rabbitmq/rabbitmq_test.go
@@ -1,17 +1,16 @@
 package rabbitmq
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/LerianStudio/lib-commons/v2/commons/log"
 	"github.com/stretchr/testify/assert"
 )
-
-// Mock for amqp.Channel
-type mockAMQPChannel struct{}
 
 // mockRabbitMQConnection extends RabbitMQConnection to allow mocking for tests
 type mockRabbitMQConnection struct {
@@ -362,4 +361,126 @@ func TestBuildRabbitMQConnectionString(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// TestEnsureChannelWithContext_ReturnsErrorOnCancelledContext verifies that
+// EnsureChannelWithContext respects context cancellation.
+func TestEnsureChannelWithContext_ReturnsErrorOnCancelledContext(t *testing.T) {
+	logger := &log.GoLogger{Level: log.InfoLevel}
+
+	conn := &RabbitMQConnection{
+		ConnectionStringSource: "amqp://guest:guest@localhost:5999", // Unreachable
+		Logger:                 logger,
+	}
+
+	// Create already cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := conn.EnsureChannelWithContext(ctx)
+
+	// Should return context.Canceled error
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestEnsureChannelWithContext_ReturnsErrorOnDeadlineExceeded(t *testing.T) {
+	logger := &log.GoLogger{Level: log.InfoLevel}
+
+	conn := &RabbitMQConnection{
+		ConnectionStringSource: "amqp://guest:guest@localhost:5999", // Unreachable
+		Logger:                 logger,
+	}
+
+	// Create context with very short deadline that's already expired
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	defer cancel()
+	time.Sleep(10 * time.Millisecond) // Let deadline expire
+
+	err := conn.EnsureChannelWithContext(ctx)
+
+	// Should return context.DeadlineExceeded error
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestEnsureChannelWithContext_TimeoutDuringDial(t *testing.T) {
+	logger := &log.GoLogger{Level: log.InfoLevel}
+
+	conn := &RabbitMQConnection{
+		// Use a non-routable IP to ensure connection hangs (doesn't immediately fail)
+		ConnectionStringSource: "amqp://guest:guest@10.255.255.1:5672",
+		Logger:                 logger,
+	}
+
+	// Use short timeout - this should NOT take 30 seconds
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := conn.EnsureChannelWithContext(ctx)
+	elapsed := time.Since(start)
+
+	// Should fail with context deadline exceeded or i/o timeout
+	assert.Error(t, err)
+
+	// Should complete within reasonable time (not 30 seconds)
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"EnsureChannelWithContext should respect context timeout, took %v", elapsed)
+}
+
+func TestEnsureChannelWithContext_UsesConnectionTimeoutField(t *testing.T) {
+	logger := &log.GoLogger{Level: log.InfoLevel}
+
+	conn := &RabbitMQConnection{
+		// Use non-routable IP to ensure connection hangs
+		ConnectionStringSource: "amqp://guest:guest@10.255.255.1:5672",
+		Logger:                 logger,
+		ConnectionTimeout:      50 * time.Millisecond, // Short custom timeout
+	}
+
+	// Use context without deadline - should use ConnectionTimeout field
+	ctx := context.Background()
+
+	start := time.Now()
+	err := conn.EnsureChannelWithContext(ctx)
+	elapsed := time.Since(start)
+
+	// Should fail with connection error
+	assert.Error(t, err)
+
+	// Should complete around ConnectionTimeout duration (with some buffer)
+	assert.Less(t, elapsed, 200*time.Millisecond,
+		"Should respect ConnectionTimeout field, took %v", elapsed)
+	assert.Greater(t, elapsed, 40*time.Millisecond,
+		"Should take at least ConnectionTimeout duration, took %v", elapsed)
+}
+
+func TestEnsureChannelWithContext_ChecksContextAfterLockAcquisition(t *testing.T) {
+	logger := &log.GoLogger{Level: log.InfoLevel}
+
+	conn := &RabbitMQConnection{
+		// Use non-routable IP so connection hangs until context is cancelled
+		ConnectionStringSource: "amqp://guest:guest@10.255.255.1:5672",
+		Logger:                 logger,
+	}
+
+	// Create context that we'll cancel after a short delay
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start goroutine that cancels context after a tiny delay
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	// Call should detect cancellation and return quickly
+	start := time.Now()
+	err := conn.EnsureChannelWithContext(ctx)
+	elapsed := time.Since(start)
+
+	// Should return an error (context.Canceled or connection error)
+	assert.Error(t, err)
+
+	// Should complete quickly due to context cancellation (not 30 seconds)
+	assert.Less(t, elapsed, 200*time.Millisecond,
+		"Should detect context cancellation quickly, took %v", elapsed)
 }


### PR DESCRIPTION
## Summary

Add context-aware RabbitMQ channel management with `EnsureChannelWithContext` method that respects context cancellation and deadlines, enabling proper timeout control for connection attempts.

## Motivation

The existing `EnsureChannel` method lacks timeout control, which can cause applications to hang indefinitely when RabbitMQ is unreachable. This is problematic for:
- Graceful shutdown scenarios where connections must be abandoned quickly
- Health checks that need bounded response times
- Request handlers with SLA requirements

The new `EnsureChannelWithContext` method allows callers to control connection timeouts via context, improving application responsiveness and reliability.

## Semantic Decision

- **Type**: `feat` (new feature)
- **Scope**: `rabbitmq`
- **Breaking change**: No - existing `EnsureChannel` method preserved for backward compatibility

## Changes

### New Files
| File | Purpose |
|------|---------|
| N/A | No new files - changes to existing files only |

### Refactored Code
| Before | After |
|--------|-------|
| `EnsureChannel()` with no timeout control | `EnsureChannelWithContext(ctx)` with context-aware timeout |
| `rc.Logger.Errorf("can't connect...")` | `rc.Logger.Error("failed to connect...", zap.Error(err))` with proper error wrapping |

### New Components

| Component | Type | Description |
|-----------|------|-------------|
| `DefaultConnectionTimeout` | `const` | Default timeout (30s) when `ConnectionTimeout` field is not set |
| `RabbitMQConnection.ConnectionTimeout` | `time.Duration` | Configurable timeout for establishing connections |
| `RabbitMQConnection.EnsureChannelWithContext(ctx)` | `method` | Context-aware channel management with timeout support |

### Implementation Details

**Timeout Resolution Priority:**
1. Remaining time until context deadline (if context has a deadline)
2. `ConnectionTimeout` field value (if set)
3. `DefaultConnectionTimeout` (30 seconds)

**Context Checks:**
- Before acquiring mutex lock (fail-fast)
- After acquiring mutex lock (detect cancellation during lock wait)
- During dial operation via custom dialer

## Test Plan
- [x] `TestEnsureChannelWithContext_ReturnsErrorOnCancelledContext` - verifies immediate return on cancelled context
- [x] `TestEnsureChannelWithContext_ReturnsErrorOnDeadlineExceeded` - verifies deadline exceeded handling
- [x] `TestEnsureChannelWithContext_TimeoutDuringDial` - verifies timeout is respected during connection attempts
- [x] `TestEnsureChannelWithContext_UsesConnectionTimeoutField` - verifies custom `ConnectionTimeout` field is honored
- [x] `TestEnsureChannelWithContext_ChecksContextAfterLockAcquisition` - verifies context cancellation detected after lock
