### PR TITLE
fix(redis): replace deprecated google.CredentialsFromJSON with validated alternative

### DIFF
--- a/commons/redis/redis.go
+++ b/commons/redis/redis.go
@@ -229,7 +229,7 @@ func (rc *RedisConnection) retrieveToken(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	creds, err := google.CredentialsFromJSON(ctx, credentialsJSON)
+	creds, err := google.CredentialsFromJSONWithType(ctx, credentialsJSON, google.ServiceAccount)
 	if err != nil {
 		return "", fmt.Errorf("parsing credentials JSON: %w", err)
 	}


### PR DESCRIPTION
Use CredentialsFromJSONWithType with google.ServiceAccount type parameter to address SA1019 staticcheck warning and validate credential type for security.

X-Lerian-Ref: 0x1

# Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Pipeline
- [ ] Tests
- [ ] Documentation

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
## Obs: Please, always remember to target your PR to develop branch instead of main.