### PR TITLE
fix(consumer): evict tenant on not-found during revalidation

### DIFF
--- a/commons/tenant-manager/consumer/multi_tenant.go
+++ b/commons/tenant-manager/consumer/multi_tenant.go
@@ -3,6 +3,7 @@ package consumer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"sync"
@@ -591,6 +592,13 @@ func (c *MultiTenantConsumer) revalidateConnectionSettings(ctx context.Context) 
 		if err != nil {
 			// If tenant service was suspended/purged, stop consumer and close connections
 			if core.IsTenantSuspendedError(err) {
+				c.evictSuspendedTenant(ctx, tenantID, logger)
+				continue
+			}
+
+			// If tenant was deleted (404), stop consumer and close connections
+			if errors.Is(err, core.ErrTenantNotFound) {
+				logger.Infof("tenant %s not found during revalidation, evicting consumer", tenantID)
 				c.evictSuspendedTenant(ctx, tenantID, logger)
 				continue
 			}


### PR DESCRIPTION
Handle ErrTenantNotFound (404) in revalidateConnectionSettings by evicting the consumer, same as suspended tenants. Previously only suspended (403) triggered eviction, leaving deleted tenants retrying indefinitely.

X-Lerian-Ref: 0x1

# Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Pipeline
- [ ] Tests
- [ ] Documentation

## Checklist
Please check each item after it's completed.

- [ ] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [ ] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [ ] I have confirmed this code is ready for review.

## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
## Obs: Please, always remember to target your PR to develop branch instead of main.