### PR TITLE
feat(client): add X-API-Key header support for service authentication

### DIFF
--- a/commons/tenant-manager/client/client.go
+++ b/commons/tenant-manager/client/client.go
@@ -55,11 +55,12 @@ type TenantSummary struct {
 // An optional circuit breaker can be enabled via WithCircuitBreaker to fail fast
 // when the Tenant Manager service is unresponsive.
 type Client struct {
-	baseURL    string
-	httpClient *http.Client
-	logger     libLog.Logger
-	cache      cache.ConfigCache
-	cacheTTL   time.Duration
+	baseURL       string
+	httpClient    *http.Client
+	logger        libLog.Logger
+	serviceAPIKey string // API key for X-API-Key header (empty = no header sent)
+	cache         cache.ConfigCache
+	cacheTTL      time.Duration
 
 	// allowInsecureHTTP permits http:// URLs when set to true.
 	// By default, only https:// URLs are accepted unless explicitly opted in
@@ -165,6 +166,17 @@ func WithCacheTTL(ttl time.Duration) ClientOption {
 func WithAllowInsecureHTTP() ClientOption {
 	return func(c *Client) {
 		c.allowInsecureHTTP = true
+	}
+}
+
+// WithServiceAPIKey sets the API key sent as X-API-Key header on all HTTP
+// requests to the Tenant Manager. When empty (default), no X-API-Key header
+// is sent, preserving backward compatibility with deployments that do not
+// require API key authentication. Typically sourced from the
+// MULTI_TENANT_SERVICE_API_KEY environment variable.
+func WithServiceAPIKey(key string) ClientOption {
+	return func(c *Client) {
+		c.serviceAPIKey = key
 	}
 }
 
@@ -471,6 +483,10 @@ func (c *Client) GetTenantConfig(ctx context.Context, tenantID, service string, 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
+	if c.serviceAPIKey != "" {
+		req.Header.Set("X-API-Key", c.serviceAPIKey)
+	}
+
 	// Inject trace context into outgoing HTTP headers for distributed tracing
 	libOpentelemetry.InjectHTTPContext(ctx, req.Header)
 
@@ -584,6 +600,10 @@ func (c *Client) GetActiveTenantsByService(ctx context.Context, service string) 
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+
+	if c.serviceAPIKey != "" {
+		req.Header.Set("X-API-Key", c.serviceAPIKey)
+	}
 
 	// Inject trace context into outgoing HTTP headers for distributed tracing
 	libOpentelemetry.InjectHTTPContext(ctx, req.Header)

--- a/commons/tenant-manager/client/client_test.go
+++ b/commons/tenant-manager/client/client_test.go
@@ -754,6 +754,119 @@ func TestIsServerError(t *testing.T) {
 	}
 }
 
+func TestWithServiceAPIKey(t *testing.T) {
+	t.Run("sets serviceAPIKey on client", func(t *testing.T) {
+		client := mustNewClient(t, "http://localhost:8080",
+			WithServiceAPIKey("my-secret-key"),
+		)
+
+		assert.Equal(t, "my-secret-key", client.serviceAPIKey)
+	})
+
+	t.Run("default client has empty serviceAPIKey", func(t *testing.T) {
+		client := mustNewClient(t, "http://localhost:8080")
+
+		assert.Empty(t, client.serviceAPIKey)
+	})
+
+	t.Run("empty string is preserved", func(t *testing.T) {
+		client := mustNewClient(t, "http://localhost:8080",
+			WithServiceAPIKey(""),
+		)
+
+		assert.Empty(t, client.serviceAPIKey)
+	})
+}
+
+func TestClient_GetTenantConfig_APIKeyHeader(t *testing.T) {
+	t.Run("sends X-API-Key header when serviceAPIKey is set", func(t *testing.T) {
+		config := newMinimalTenantConfig()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "my-secret-key", r.Header.Get("X-API-Key"))
+
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(config))
+		}))
+		defer server.Close()
+
+		client := mustNewClient(t, server.URL, WithServiceAPIKey("my-secret-key"))
+		ctx := context.Background()
+
+		result, err := client.GetTenantConfig(ctx, "tenant-123", "ledger")
+
+		require.NoError(t, err)
+		assert.Equal(t, "tenant-123", result.ID)
+	})
+
+	t.Run("omits X-API-Key header when serviceAPIKey is empty", func(t *testing.T) {
+		config := newMinimalTenantConfig()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Empty(t, r.Header.Get("X-API-Key"), "X-API-Key header should not be present")
+
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(config))
+		}))
+		defer server.Close()
+
+		client := mustNewClient(t, server.URL)
+		ctx := context.Background()
+
+		result, err := client.GetTenantConfig(ctx, "tenant-123", "ledger")
+
+		require.NoError(t, err)
+		assert.Equal(t, "tenant-123", result.ID)
+	})
+}
+
+func TestClient_GetActiveTenantsByService_APIKeyHeader(t *testing.T) {
+	t.Run("sends X-API-Key header when serviceAPIKey is set", func(t *testing.T) {
+		tenants := []*TenantSummary{
+			{ID: "tenant-1", Name: "Acme Corp", Status: "active"},
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "my-secret-key", r.Header.Get("X-API-Key"))
+
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(tenants))
+		}))
+		defer server.Close()
+
+		client := mustNewClient(t, server.URL, WithServiceAPIKey("my-secret-key"))
+		ctx := context.Background()
+
+		result, err := client.GetActiveTenantsByService(ctx, "ledger")
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "tenant-1", result[0].ID)
+	})
+
+	t.Run("omits X-API-Key header when serviceAPIKey is empty", func(t *testing.T) {
+		tenants := []*TenantSummary{
+			{ID: "tenant-1", Name: "Acme Corp", Status: "active"},
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Empty(t, r.Header.Get("X-API-Key"), "X-API-Key header should not be present")
+
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(tenants))
+		}))
+		defer server.Close()
+
+		client := mustNewClient(t, server.URL)
+		ctx := context.Background()
+
+		result, err := client.GetActiveTenantsByService(ctx, "ledger")
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+	})
+}
+
 func TestIsCircuitBreakerOpenError(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Add WithServiceAPIKey option to tenant-manager client. When configured via MULTI_TENANT_SERVICE_API_KEY env var, the client sends X-API-Key header on all requests to tenant-manager. Backward compatible — empty key means no header.

X-Lerian-Ref: 0x1

# Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Pipeline
- [ ] Tests
- [ ] Documentation

## Checklist
Please check each item after it's completed.

- [ ] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [ ] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [ ] I have confirmed this code is ready for review.

## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
## Obs: Please, always remember to target your PR to develop branch instead of main.