### PR TITLE
fix(tenant-middleware): remove hasUpstreamAuthAssertion gate

### DIFF
--- a/commons/tenant-manager/middleware/multi_pool.go
+++ b/commons/tenant-manager/middleware/multi_pool.go
@@ -323,11 +323,7 @@ func (m *MultiPoolMiddleware) isPublicPath(path string) bool {
 }
 
 // extractTenantID extracts the tenant ID from the JWT token in the
-// Authorization header.
-//
-// Token signature/authorization is validated by upstream lib-auth middleware
-// before this function is called. Middleware ordering is the enforcement mechanism.
-// See: https://github.com/LerianStudio/lib-commons/issues/345
+// Authorization header. Token signature is validated by upstream auth middleware.
 func (m *MultiPoolMiddleware) extractTenantID(c *fiber.Ctx) (string, error) {
 	accessToken := libHTTP.ExtractTokenFromHeader(c)
 	if accessToken == "" {

--- a/commons/tenant-manager/middleware/tenant.go
+++ b/commons/tenant-manager/middleware/tenant.go
@@ -114,12 +114,7 @@ func (m *TenantMiddleware) WithTenantDB(c *fiber.Ctx) error {
 	}
 
 	// Parse JWT token without signature verification.
-	//
-	// Token signature/authorization is validated by upstream lib-auth middleware
-	// (Authorize chain) before this middleware runs. Middleware ordering is the
-	// enforcement mechanism — hasUpstreamAuthAssertion was removed because lib-auth
-	// does not set Fiber locals after authorization, making the assertion unreliable.
-	// See: https://github.com/LerianStudio/lib-commons/issues/345
+	// Token signature is validated by upstream auth middleware before this point.
 	token, _, err := new(jwt.Parser).ParseUnverified(accessToken, jwt.MapClaims{})
 	if err != nil {
 		logger.Base().Log(ctx, liblog.LevelError, "failed to parse JWT token", liblog.Err(err))


### PR DESCRIPTION
## Problem

`hasUpstreamAuthAssertion()` checked for `c.Locals("user_id")` to verify that upstream auth middleware had run before allowing `ParseUnverified` on the JWT. However, lib-auth never sets this local after successful authorization via plugin-auth — it makes the HTTP call, gets the `authorized: true` response, and calls `c.Next()` without storing anything in Fiber context.

This caused **100% of authenticated requests to fail with 401** in every service using `TenantMiddleware` or `MultiPoolMiddleware` with lib-commons v4.

Discussed and decided with Jefferson Rodrigues (CTO).

## Fix

Remove `hasUpstreamAuthAssertion()` and its call sites in both `tenant.go` and `multi_pool.go`. Middleware chain ordering is the enforcement mechanism — lib-auth runs before the tenant middleware by convention, which is how v3 worked.

The comment block explaining the security contract is updated to reflect this.

## Tests

All `commons/tenant-manager/...` tests pass.

Closes #345