### PR TITLE
feat: add AllowInsecureHTTP option to MultiTenantConsumer config

### DIFF
--- a/commons/tenant-manager/consumer/multi_tenant.go
+++ b/commons/tenant-manager/consumer/multi_tenant.go
@@ -68,6 +68,13 @@ type MultiTenantConfig struct {
 	// Default: 500ms
 	DiscoveryTimeout time.Duration
 
+	// AllowInsecureHTTP permits the use of http:// (plaintext) URLs for the
+	// MultiTenantURL. By default, only https:// is accepted by the underlying
+	// client. Set this to true for in-cluster Kubernetes service URLs that use
+	// plain HTTP (e.g., http://tenant-manager.namespace.svc.cluster.local:4003).
+	// Default: false
+	AllowInsecureHTTP bool
+
 	// EagerStart controls whether consumers are started immediately for all
 	// discovered tenants at startup and during sync. When true (default),
 	// Run() bootstraps consumers for all known tenants and syncTenants()
@@ -205,9 +212,15 @@ func NewMultiTenantConsumerWithError(
 
 	// Create Tenant Manager client for fallback if URL is configured
 	if config.MultiTenantURL != "" {
-		pmClient, err := client.NewClient(config.MultiTenantURL, consumer.logger.Base(),
+		clientOpts := []client.ClientOption{
 			client.WithServiceAPIKey(config.ServiceAPIKey),
-		)
+		}
+
+		if config.AllowInsecureHTTP {
+			clientOpts = append(clientOpts, client.WithAllowInsecureHTTP())
+		}
+
+		pmClient, err := client.NewClient(config.MultiTenantURL, consumer.logger.Base(), clientOpts...)
 		if err != nil {
 			return nil, fmt.Errorf("consumer.NewMultiTenantConsumerWithError: invalid MultiTenantURL: %w", err)
 		}

--- a/commons/tenant-manager/consumer/multi_tenant_test.go
+++ b/commons/tenant-manager/consumer/multi_tenant_test.go
@@ -849,6 +849,7 @@ func TestMultiTenantConsumer_DefaultMultiTenantConfig(t *testing.T) {
 				"default DiscoveryTimeout should be %s", tt.expectedDiscoveryTO)
 			assert.Empty(t, config.MultiTenantURL, "default MultiTenantURL should be empty")
 			assert.Empty(t, config.Service, "default Service should be empty")
+			assert.False(t, config.AllowInsecureHTTP, "default AllowInsecureHTTP should be false")
 		})
 	}
 }
@@ -894,6 +895,18 @@ func TestMultiTenantConsumer_NewWithZeroConfig(t *testing.T) {
 			},
 			expectedSync:     30 * time.Second,
 			expectedWorkers:  0, // WorkersPerQueue is deprecated, default is 0
+			expectedPrefetch: 10,
+			expectPMClient:   true,
+		},
+		{
+			name: "creates_pmClient_with_http_URL_when_AllowInsecureHTTP_set",
+			config: MultiTenantConfig{
+				MultiTenantURL:    "http://tenant-manager.namespace.svc.cluster.local:4003",
+				ServiceAPIKey:     "test-key",
+				AllowInsecureHTTP: true,
+			},
+			expectedSync:     30 * time.Second,
+			expectedWorkers:  0,
 			expectedPrefetch: 10,
 			expectPMClient:   true,
 		},
@@ -3014,6 +3027,76 @@ func TestMultiTenantConsumer_RevalidateSettings_StopsSuspendedTenant(t *testing.
 			_, healthyRetryExists := consumer.retryState.Load(tt.healthyTenantID)
 			assert.True(t, healthyRetryExists,
 				"retryState should still exist for healthy tenant %q", tt.healthyTenantID)
+		})
+	}
+}
+
+// TestMultiTenantConsumer_AllowInsecureHTTP verifies that the AllowInsecureHTTP
+// config field controls whether http:// MultiTenantURLs are accepted by the constructor.
+func TestMultiTenantConsumer_AllowInsecureHTTP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		config      MultiTenantConfig
+		expectError bool
+		errContains string
+	}{
+		{
+			name: "rejects_http_URL_when_AllowInsecureHTTP_is_false",
+			config: MultiTenantConfig{
+				MultiTenantURL: "http://tenant-manager.namespace.svc.cluster.local:4003",
+				ServiceAPIKey:  "test-key",
+			},
+			expectError: true,
+			errContains: "insecure HTTP",
+		},
+		{
+			name: "accepts_http_URL_when_AllowInsecureHTTP_is_true",
+			config: MultiTenantConfig{
+				MultiTenantURL:    "http://tenant-manager.namespace.svc.cluster.local:4003",
+				ServiceAPIKey:     "test-key",
+				AllowInsecureHTTP: true,
+			},
+			expectError: false,
+		},
+		{
+			name: "accepts_https_URL_regardless_of_AllowInsecureHTTP",
+			config: MultiTenantConfig{
+				MultiTenantURL: "https://tenant-manager.dev.example.com",
+				ServiceAPIKey:  "test-key",
+			},
+			expectError: false,
+		},
+		{
+			name: "no_error_when_MultiTenantURL_is_empty",
+			config: MultiTenantConfig{
+				MultiTenantURL: "",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			redisClient := dummyRedisClient(t)
+			consumer, err := NewMultiTenantConsumerWithError(
+				dummyRabbitMQManager(), redisClient, tt.config, testutil.NewMockLogger(),
+			)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				assert.Nil(t, consumer)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, consumer)
+				if consumer != nil {
+					_ = consumer.Close()
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Problem

`NewMultiTenantConsumerWithError` creates an internal `client.NewClient` to communicate with the Tenant Manager API as a fallback when Redis cache misses. This internal client was hardcoded with only `WithServiceAPIKey()` — it never passed `WithAllowInsecureHTTP()`.

Since lib-commons v4, `client.NewClient` enforces HTTPS by default and rejects `http://` URLs unless `WithAllowInsecureHTTP()` is explicitly provided. This caused a fatal crash on any service using the multi-tenant consumer with an in-cluster HTTP URL:

```
failed to initialize worker service: create multi-tenant consumer:
  consumer.NewMultiTenantConsumerWithError: invalid MultiTenantURL:
    client.NewClient: insecure HTTP is not allowed; use HTTPS or enable WithAllowInsecureHTTP()
```

### Who was affected

Any service that:
1. Uses `tmconsumer.NewMultiTenantConsumerWithError` (workers with per-tenant RabbitMQ vhost isolation)
2. Connects to tenant-manager via internal Kubernetes service URL (`http://tenant-manager.namespace.svc.cluster.local:4003`)

Concrete case: **fetcher-worker** on clotilde-dev was in CrashLoopBackOff because of this. The reporter-worker was not affected because it uses HTTPS via ingress.

### Why the caller could not work around it

`MultiTenantConfig` had no field to control insecure HTTP behavior. The caller (fetcher) correctly passed `WithAllowInsecureHTTP()` to its own `initTenantManagerClient()`, but the consumer internally created a **second** client without that option — and there was no way to propagate it.

## Solution

- Add `AllowInsecureHTTP bool` field to `MultiTenantConfig`
- When `true`, pass `client.WithAllowInsecureHTTP()` to the internal `client.NewClient` call
- Default remains `false` (secure by default — no behavior change for existing callers)

### Caller usage (fetcher/reporter workers)

```go
mtConfig := tmconsumer.DefaultMultiTenantConfig()
mtConfig.MultiTenantURL = cfg.MultiTenantURL
mtConfig.ServiceAPIKey = cfg.MultiTenantServiceAPIKey
mtConfig.AllowInsecureHTTP = strings.HasPrefix(strings.ToLower(cfg.MultiTenantURL), "http://") && strings.ToLower(cfg.EnvName) != "production"
```

## Tests

- `rejects_http_URL_when_AllowInsecureHTTP_is_false` — confirms default secure behavior
- `accepts_http_URL_when_AllowInsecureHTTP_is_true` — confirms the fix works
- `accepts_https_URL_regardless_of_AllowInsecureHTTP` — confirms HTTPS is always accepted
- `no_error_when_MultiTenantURL_is_empty` — confirms no regression when URL is not configured
- Default config assertion: `AllowInsecureHTTP` is `false` by default
- Existing test updated: `creates_pmClient_with_http_URL_when_AllowInsecureHTTP_set`