### PR TITLE
fix(otel): normalize endpoint URL and infer insecure mode from scheme

### DIFF
--- a/commons/opentelemetry/otel.go
+++ b/commons/opentelemetry/otel.go
@@ -98,6 +98,22 @@ func NewTelemetry(cfg TelemetryConfig) (*Telemetry, error) {
 		cfg.Redactor = NewDefaultRedactor()
 	}
 
+	// Normalize endpoint: strip URL scheme and infer security mode.
+	// gRPC WithEndpoint() expects host:port, not a full URL.
+	// Consumers commonly pass OTEL_EXPORTER_OTLP_ENDPOINT as "http://host:4317".
+	if ep := strings.TrimSpace(cfg.CollectorExporterEndpoint); ep != "" {
+		switch {
+		case strings.HasPrefix(ep, "http://"):
+			cfg.CollectorExporterEndpoint = strings.TrimPrefix(ep, "http://")
+			cfg.InsecureExporter = true
+		case strings.HasPrefix(ep, "https://"):
+			cfg.CollectorExporterEndpoint = strings.TrimPrefix(ep, "https://")
+		default:
+			// No scheme — assume insecure (common in k8s internal comms).
+			cfg.InsecureExporter = true
+		}
+	}
+
 	if cfg.EnableTelemetry && strings.TrimSpace(cfg.CollectorExporterEndpoint) == "" {
 		return nil, ErrEmptyEndpoint
 	}

--- a/commons/opentelemetry/otel_test.go
+++ b/commons/opentelemetry/otel_test.go
@@ -93,6 +93,75 @@ func TestNewTelemetry_DefaultPropagatorAndRedactor(t *testing.T) {
 }
 
 // ===========================================================================
+// 1b. Endpoint normalization
+// ===========================================================================
+
+func TestNewTelemetry_EndpointNormalization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		endpoint         string
+		wantEndpoint     string
+		wantInsecure     bool
+		insecureOverride bool // initial InsecureExporter value
+	}{
+		{
+			name:         "http scheme stripped and insecure inferred",
+			endpoint:     "http://otel-collector:4317",
+			wantEndpoint: "otel-collector:4317",
+			wantInsecure: true,
+		},
+		{
+			name:         "https scheme stripped and insecure stays false",
+			endpoint:     "https://otel-collector:4317",
+			wantEndpoint: "otel-collector:4317",
+			wantInsecure: false,
+		},
+		{
+			name:         "no scheme defaults to insecure",
+			endpoint:     "otel-collector:4317",
+			wantEndpoint: "otel-collector:4317",
+			wantInsecure: true,
+		},
+		{
+			name:             "https with explicit insecure override preserved",
+			endpoint:         "https://otel-collector:4317",
+			insecureOverride: true,
+			wantEndpoint:     "otel-collector:4317",
+			wantInsecure:     true,
+		},
+		{
+			name:         "http with trailing slash",
+			endpoint:     "http://otel-collector:4317/",
+			wantEndpoint: "otel-collector:4317/",
+			wantInsecure: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Use telemetry disabled so we don't need a real collector.
+			tl, err := NewTelemetry(TelemetryConfig{
+				LibraryName:               "test-lib",
+				EnableTelemetry:            false,
+				CollectorExporterEndpoint:  tt.endpoint,
+				InsecureExporter:           tt.insecureOverride,
+				Logger:                     log.NewNop(),
+			})
+			require.NoError(t, err)
+			require.NotNil(t, tl)
+			assert.Equal(t, tt.wantEndpoint, tl.CollectorExporterEndpoint,
+				"endpoint should be normalized")
+			assert.Equal(t, tt.wantInsecure, tl.InsecureExporter,
+				"InsecureExporter should be inferred from scheme")
+		})
+	}
+}
+
+// ===========================================================================
 // 2. Telemetry methods on nil receiver
 // ===========================================================================
 


### PR DESCRIPTION
## Problem

`otlptracegrpc.WithEndpoint()` (and metric/log equivalents) expect `host:port`, not a full URL. Consumers commonly pass `OTEL_EXPORTER_OTLP_ENDPOINT` as `http://host:4317`.

When `InsecureExporter` is `false` (the default since v4), the gRPC SDK assumes TLS and appends `:443`, resulting in `http://host:4317:443` — which fails with:
```
rpc error: code = Unavailable desc = invalid target address http://host:4317,
error info: address http://host:4317:443: too many colons in address
```

This affects all services on lib-commons v4 that don't explicitly set `InsecureExporter: true` (tenant-manager, matcher, etc).

## Root Cause

Introduced in [`387a994`](https://github.com/LerianStudio/lib-commons/commit/387a994) (March 7, 2026) when `InsecureExporter` became a conditional flag. Previously `WithInsecure()` was always hardcoded in v2/v3.

## Fix

Auto-detect scheme in `CollectorExporterEndpoint` during `NewTelemetry()`:
- `http://` → strip scheme, set `InsecureExporter = true`
- `https://` → strip scheme, keep `InsecureExporter` as-is
- No scheme → assume insecure (common in k8s internal comms)

**Backwards-compatible**: no consumer code changes needed. Existing consumers that pass `http://host:4317` will work correctly without adding `InsecureExporter: true`.

## Tests

5 table-driven test cases covering all normalization scenarios. All existing tests pass.