### PR TITLE
fix(http): revert Ping response from 'pong' to 'healthy' for lib-auth compatibility

### DIFF
--- a/commons/net/http/error_test.go
+++ b/commons/net/http/error_test.go
@@ -937,7 +937,7 @@ func TestPing(t *testing.T) {
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	assert.Equal(t, "pong", string(body))
+	assert.Equal(t, "healthy", string(body))
 }
 
 func TestVersion(t *testing.T) {

--- a/commons/net/http/handler.go
+++ b/commons/net/http/handler.go
@@ -14,13 +14,13 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// Ping returns HTTP Status 200 with response "pong".
+// Ping returns HTTP Status 200 with response "healthy".
 func Ping(c *fiber.Ctx) error {
 	if c == nil {
 		return ErrContextNotFound
 	}
 
-	return c.SendString("pong")
+	return c.SendString("healthy")
 }
 
 // Version returns HTTP Status 200 with the service version from the VERSION


### PR DESCRIPTION
## Problem

The `Ping()` handler was changed in v4 to return `"pong"`, breaking backward compatibility with `lib-auth` which performs an exact string comparison:

```go
// lib-auth/auth/middleware/middleware.go:95
if string(body) == "healthy" {
    l.Infof("Connected to %s ✅", pluginName)
} else {
    l.Errorf(failedToConnectMsg, string(body))
}
```

Any service using `lib-auth` (e.g. `midaz`, `plugin-fees`, `plugin-identity`) will fail to connect to `plugin-auth` (already migrated to lib-commons v4) because it receives `"pong"` instead of `"healthy"`.

## Fix

Revert `Ping()` to return `"healthy"` and update the corresponding test.

## Note

If the response value needs to change in the future, `lib-auth` must be updated in the same release to avoid a contract break between services.

Fixes the lib-auth connection failure detected before the RC cut (2026-03-20).