### PR TITLE
feat(log): automatic tenant_id injection in multi-tenant log output

### DIFF
--- a/commons/tenant-manager/internal/logcompat/logger.go
+++ b/commons/tenant-manager/internal/logcompat/logger.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	liblog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	tmlog "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/log"
 )
 
 type Logger struct {
@@ -16,7 +17,7 @@ func New(logger liblog.Logger) *Logger {
 		logger = liblog.NewNop()
 	}
 
-	return &Logger{base: logger}
+	return &Logger{base: tmlog.NewTenantAwareLogger(logger)}
 }
 
 func (l *Logger) WithFields(kv ...any) *Logger {

--- a/commons/tenant-manager/log/tenant_logger.go
+++ b/commons/tenant-manager/log/tenant_logger.go
@@ -1,0 +1,44 @@
+package log
+
+import (
+	"context"
+
+	"github.com/LerianStudio/lib-commons/v4/commons/log"
+	tmcore "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/core"
+)
+
+type TenantAwareLogger struct {
+	base log.Logger
+}
+
+func NewTenantAwareLogger(base log.Logger) *TenantAwareLogger {
+	return &TenantAwareLogger{base: base}
+}
+
+func (l *TenantAwareLogger) Log(ctx context.Context, level log.Level, msg string, fields ...log.Field) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if tenantID := tmcore.GetTenantIDFromContext(ctx); tenantID != "" {
+		fields = append(fields, log.String("tenant_id", tenantID))
+	}
+
+	l.base.Log(ctx, level, msg, fields...)
+}
+
+func (l *TenantAwareLogger) With(fields ...log.Field) log.Logger {
+	return l.base.With(fields...)
+}
+
+func (l *TenantAwareLogger) WithGroup(name string) log.Logger {
+	return l.base.WithGroup(name)
+}
+
+func (l *TenantAwareLogger) Enabled(level log.Level) bool {
+	return l.base.Enabled(level)
+}
+
+func (l *TenantAwareLogger) Sync(ctx context.Context) error {
+	return l.base.Sync(ctx)
+}

--- a/commons/tenant-manager/log/tenant_logger_test.go
+++ b/commons/tenant-manager/log/tenant_logger_test.go
@@ -1,0 +1,154 @@
+package log
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LerianStudio/lib-commons/v4/commons/log"
+	"github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestTenantAwareLogger_Log(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("injects tenant_id when present in context", func(t *testing.T) {
+		mockLogger := log.NewMockLogger(ctrl)
+
+		var capturedFields []log.Field
+
+		mockLogger.EXPECT().
+			Log(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, level log.Level, msg string, fields ...log.Field) {
+				capturedFields = fields
+			})
+
+		logger := NewTenantAwareLogger(mockLogger)
+		ctx := core.SetTenantIDInContext(context.Background(), "tenant-123")
+
+		logger.Log(ctx, log.LevelInfo, "test message", log.String("key", "value"))
+
+		require.Len(t, capturedFields, 2)
+		assert.Equal(t, "key", capturedFields[0].Key)
+		assert.Equal(t, "value", capturedFields[0].Value)
+		assert.Equal(t, "tenant_id", capturedFields[1].Key)
+		assert.Equal(t, "tenant-123", capturedFields[1].Value)
+	})
+
+	t.Run("works normally when tenant_id is not in context", func(t *testing.T) {
+		mockLogger := log.NewMockLogger(ctrl)
+
+		var capturedFields []log.Field
+
+		mockLogger.EXPECT().
+			Log(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, level log.Level, msg string, fields ...log.Field) {
+				capturedFields = fields
+			})
+
+		logger := NewTenantAwareLogger(mockLogger)
+		ctx := context.Background()
+
+		logger.Log(ctx, log.LevelInfo, "test message", log.String("key", "value"))
+
+		require.Len(t, capturedFields, 1)
+		assert.Equal(t, "key", capturedFields[0].Key)
+		assert.Equal(t, "value", capturedFields[0].Value)
+	})
+
+	t.Run("does not overwrite caller-provided tenant_id field", func(t *testing.T) {
+		mockLogger := log.NewMockLogger(ctrl)
+
+		var capturedFields []log.Field
+
+		mockLogger.EXPECT().
+			Log(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, level log.Level, msg string, fields ...log.Field) {
+				capturedFields = fields
+			})
+
+		logger := NewTenantAwareLogger(mockLogger)
+		ctx := core.SetTenantIDInContext(context.Background(), "tenant-123")
+
+		logger.Log(ctx, log.LevelInfo, "test message",
+			log.String("tenant_id", "caller-tenant"),
+			log.String("key", "value"),
+		)
+
+		require.Len(t, capturedFields, 3)
+		assert.Equal(t, "tenant_id", capturedFields[0].Key)
+		assert.Equal(t, "caller-tenant", capturedFields[0].Value)
+		assert.Equal(t, "key", capturedFields[1].Key)
+		assert.Equal(t, "value", capturedFields[1].Value)
+		assert.Equal(t, "tenant_id", capturedFields[2].Key)
+		assert.Equal(t, "tenant-123", capturedFields[2].Value)
+	})
+
+	t.Run("nil context handled gracefully", func(t *testing.T) {
+		mockLogger := log.NewMockLogger(ctrl)
+
+		mockLogger.EXPECT().
+			Log(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, level log.Level, msg string, fields ...log.Field) {
+				assert.NotNil(t, ctx, "base logger should receive non-nil context")
+			})
+
+		logger := NewTenantAwareLogger(mockLogger)
+
+		logger.Log(nil, log.LevelInfo, "test message")
+	})
+}
+
+func TestTenantAwareLogger_OtherMethods(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("With delegates to base logger", func(t *testing.T) {
+		mockLogger := log.NewMockLogger(ctrl)
+		wrappedLogger := log.NewMockLogger(ctrl)
+
+		mockLogger.EXPECT().With(log.String("key", "value")).Return(wrappedLogger)
+
+		logger := NewTenantAwareLogger(mockLogger)
+		result := logger.With(log.String("key", "value"))
+
+		assert.Equal(t, wrappedLogger, result)
+	})
+
+	t.Run("WithGroup delegates to base logger", func(t *testing.T) {
+		mockLogger := log.NewMockLogger(ctrl)
+		wrappedLogger := log.NewMockLogger(ctrl)
+
+		mockLogger.EXPECT().WithGroup("group").Return(wrappedLogger)
+
+		logger := NewTenantAwareLogger(mockLogger)
+		result := logger.WithGroup("group")
+
+		assert.Equal(t, wrappedLogger, result)
+	})
+
+	t.Run("Enabled delegates to base logger", func(t *testing.T) {
+		mockLogger := log.NewMockLogger(ctrl)
+
+		mockLogger.EXPECT().Enabled(log.LevelInfo).Return(true)
+
+		logger := NewTenantAwareLogger(mockLogger)
+		result := logger.Enabled(log.LevelInfo)
+
+		assert.True(t, result)
+	})
+
+	t.Run("Sync delegates to base logger", func(t *testing.T) {
+		mockLogger := log.NewMockLogger(ctrl)
+
+		mockLogger.EXPECT().Sync(gomock.Any()).Return(nil)
+
+		logger := NewTenantAwareLogger(mockLogger)
+		err := logger.Sync(context.Background())
+
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Problem

In multi-tenant workers, debugging requires filtering logs by tenant_id. Previously devs had to pass it manually on every log call — easy to forget, inconsistent in production.

## Solution

TenantAwareLogger wraps the base logger and extracts tenant_id from context automatically on every Log() call. Integrated in logcompat.New(), so consumer, MongoDB manager, and RabbitMQ manager all get it for free.

Zero behavior change when tenant_id is not in context.

## Changes

- commons/tenant-manager/log/tenant_logger.go: new TenantAwareLogger
- commons/tenant-manager/internal/logcompat/: integrate TenantAwareLogger in New()
- commons/tenant-manager/log/tenant_logger_test.go: tests

Closes #359