### PR TITLE
refactor(consumer): remove lazy mode, keep only eager start

### DIFF
--- a/commons/tenant-manager/consumer/multi_tenant.go
+++ b/commons/tenant-manager/consumer/multi_tenant.go
@@ -75,12 +75,9 @@ type MultiTenantConfig struct {
 	// Default: false
 	AllowInsecureHTTP bool
 
-	// EagerStart controls whether consumers are started immediately for all
-	// discovered tenants at startup and during sync. When true (default),
-	// Run() bootstraps consumers for all known tenants and syncTenants()
-	// auto-starts consumers for newly discovered tenants. When false (lazy mode),
-	// consumers are only started on demand via EnsureConsumerStarted().
-	// Default: true
+	// Deprecated: EagerStart is ignored. Consumers are always started eagerly.
+	// This field is retained only for backward compatibility with existing configs;
+	// setting it has no effect. It will be removed in a future major version.
 	EagerStart bool
 }
 
@@ -90,7 +87,6 @@ func DefaultMultiTenantConfig() MultiTenantConfig {
 		SyncInterval:     30 * time.Second,
 		PrefetchCount:    10,
 		DiscoveryTimeout: 500 * time.Millisecond,
-		EagerStart:       true,
 	}
 }
 
@@ -113,16 +109,15 @@ func WithMongoManager(m *tmmongo.Manager) Option {
 
 // MultiTenantConsumer manages message consumption across multiple tenant vhosts.
 // It dynamically discovers tenants from Redis cache and spawns consumer goroutines.
-// In lazy mode, Run() populates knownTenants without starting consumers immediately.
-// Consumers are spawned on-demand via ensureConsumerStarted() when the first message
-// or external trigger arrives for a tenant.
+// Run() discovers tenants and eagerly starts consumers for all known tenants.
+// New tenants discovered during background sync are also started immediately.
 type MultiTenantConsumer struct {
 	rabbitmq     *tmrabbitmq.Manager
 	redisClient  redis.UniversalClient
 	pmClient     *client.Client // Tenant Manager client for fallback
 	handlers     map[string]HandlerFunc
 	tenants      map[string]context.CancelFunc // Active tenant goroutines
-	knownTenants map[string]bool               // Discovered tenants (lazy mode: populated without starting consumers)
+	knownTenants map[string]bool               // Discovered tenants (populated by discovery and sync)
 	// tenantAbsenceCount tracks consecutive syncs each tenant was missing from the fetched list.
 	// Used to avoid removing tenants on a single transient incomplete fetch.
 	tenantAbsenceCount map[string]int
@@ -260,9 +255,8 @@ func (c *MultiTenantConsumer) Register(queueName string, handler HandlerFunc) er
 }
 
 // Run starts the multi-tenant consumer.
-// It discovers tenants (non-blocking, soft failure) and starts background polling.
-// When EagerStart is true (default), consumers are started immediately for all
-// discovered tenants. When false, consumers are deferred to on-demand triggers.
+// It discovers tenants (non-blocking, soft failure), eagerly starts consumers
+// for all discovered tenants, and starts background polling for new tenants.
 // Returns nil even on discovery failure (soft failure).
 func (c *MultiTenantConsumer) Run(ctx context.Context) error {
 	baseLogger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
@@ -283,11 +277,6 @@ func (c *MultiTenantConsumer) Run(ctx context.Context) error {
 	c.parentCtx = ctx
 	c.mu.Unlock()
 
-	connectionMode := "lazy"
-	if c.config.EagerStart {
-		connectionMode = "eager"
-	}
-
 	// Discover tenants without blocking (soft failure - does not start consumers)
 	c.discoverTenants(ctx)
 
@@ -296,11 +285,11 @@ func (c *MultiTenantConsumer) Run(ctx context.Context) error {
 	knownCount := len(c.knownTenants)
 	c.mu.RUnlock()
 
-	logger.InfofCtx(ctx, "starting multi-tenant consumer, connection_mode=%s, known_tenants=%d",
-		connectionMode, knownCount)
+	logger.InfofCtx(ctx, "starting multi-tenant consumer, connection_mode=eager, known_tenants=%d",
+		knownCount)
 
-	// Eager mode: start consumers for all discovered tenants immediately
-	if c.config.EagerStart && knownCount > 0 {
+	// Eager start: start consumers for all discovered tenants immediately
+	if knownCount > 0 {
 		c.eagerStartKnownTenants(ctx)
 	}
 
@@ -360,7 +349,6 @@ type Stats struct {
 	TenantIDs        []string `json:"tenantIds"`
 	RegisteredQueues []string `json:"registeredQueues"`
 	Closed           bool     `json:"closed"`
-	ConnectionMode   string   `json:"connectionMode"`
 	KnownTenants     int      `json:"knownTenants"`
 	KnownTenantIDs   []string `json:"knownTenantIds"`
 	PendingTenants   int      `json:"pendingTenants"`

--- a/commons/tenant-manager/consumer/multi_tenant_consume.go
+++ b/commons/tenant-manager/consumer/multi_tenant_consume.go
@@ -396,7 +396,6 @@ func (c *MultiTenantConsumer) resetRetryState(tenantID string) {
 // ensureConsumerStarted ensures a consumer is running for the given tenant.
 // It uses double-check locking with a per-tenant mutex to guarantee exactly-once
 // consumer spawning under concurrent access.
-// This is the primary entry point for on-demand consumer creation in lazy mode.
 //
 // Consumers are only started for tenants that are known (resolved via discovery or
 // sync). Unknown tenants are rejected to prevent starting consumers for tenants
@@ -465,13 +464,6 @@ func (c *MultiTenantConsumer) ensureConsumerStarted(ctx context.Context, tenantI
 	c.mu.Lock()
 	c.startTenantConsumer(startCtx, tenantID)
 	c.mu.Unlock()
-}
-
-// EnsureConsumerStarted is the public API for triggering on-demand consumer spawning.
-// It is safe for concurrent use by multiple goroutines.
-// If the consumer for the given tenant is already running, this is a no-op.
-func (c *MultiTenantConsumer) EnsureConsumerStarted(ctx context.Context, tenantID string) {
-	c.ensureConsumerStarted(ctx, tenantID)
 }
 
 // IsDegraded returns true if the given tenant is currently in a degraded state

--- a/commons/tenant-manager/consumer/multi_tenant_retry_test.go
+++ b/commons/tenant-manager/consumer/multi_tenant_retry_test.go
@@ -80,7 +80,7 @@ func TestMultiTenantConsumer_RetryStateIsolation(t *testing.T) {
 }
 
 // TestMultiTenantConsumer_Stats_Enhanced verifies the enhanced Stats() API
-// returns ConnectionMode, KnownTenants, PendingTenants, and DegradedTenants.
+// returns KnownTenants, PendingTenants, and DegradedTenants.
 func TestMultiTenantConsumer_Stats_Enhanced(t *testing.T) {
 	t.Parallel()
 
@@ -89,18 +89,15 @@ func TestMultiTenantConsumer_Stats_Enhanced(t *testing.T) {
 		redisTenantIDs        []string
 		startConsumerForIDs   []string
 		degradeTenantIDs      []string
-		eagerStart            bool
 		expectedKnown         int
 		expectedActive        int
 		expectedPending       int
 		expectedDegradedCount int
-		expectedConnMode      string
 	}{
-		{name: "all_tenants_pending_in_lazy_mode", redisTenantIDs: []string{"tenant-a", "tenant-b", "tenant-c"}, expectedKnown: 3, expectedActive: 0, expectedPending: 3, expectedDegradedCount: 0, expectedConnMode: "lazy"},
-		{name: "mix_of_active_and_pending", redisTenantIDs: []string{"tenant-a", "tenant-b", "tenant-c"}, startConsumerForIDs: []string{"tenant-a"}, expectedKnown: 3, expectedActive: 1, expectedPending: 2, expectedDegradedCount: 0, expectedConnMode: "lazy"},
-		{name: "degraded_tenant_appears_in_stats", redisTenantIDs: []string{"tenant-a", "tenant-b"}, degradeTenantIDs: []string{"tenant-b"}, expectedKnown: 2, expectedActive: 0, expectedPending: 2, expectedDegradedCount: 1, expectedConnMode: "lazy"},
-		{name: "empty_consumer_returns_zero_stats", expectedKnown: 0, expectedActive: 0, expectedPending: 0, expectedDegradedCount: 0, expectedConnMode: "lazy"},
-		{name: "eager_mode_reports_connection_mode", redisTenantIDs: []string{"tenant-a"}, eagerStart: true, expectedKnown: 1, expectedActive: 0, expectedPending: 1, expectedDegradedCount: 0, expectedConnMode: "eager"},
+		{name: "all_tenants_pending", redisTenantIDs: []string{"tenant-a", "tenant-b", "tenant-c"}, expectedKnown: 3, expectedActive: 0, expectedPending: 3, expectedDegradedCount: 0},
+		{name: "mix_of_active_and_pending", redisTenantIDs: []string{"tenant-a", "tenant-b", "tenant-c"}, startConsumerForIDs: []string{"tenant-a"}, expectedKnown: 3, expectedActive: 1, expectedPending: 2, expectedDegradedCount: 0},
+		{name: "degraded_tenant_appears_in_stats", redisTenantIDs: []string{"tenant-a", "tenant-b"}, degradeTenantIDs: []string{"tenant-b"}, expectedKnown: 2, expectedActive: 0, expectedPending: 2, expectedDegradedCount: 1},
+		{name: "empty_consumer_returns_zero_stats", expectedKnown: 0, expectedActive: 0, expectedPending: 0, expectedDegradedCount: 0},
 	}
 
 	for _, tt := range tests {
@@ -119,7 +116,6 @@ func TestMultiTenantConsumer_Stats_Enhanced(t *testing.T) {
 				WorkersPerQueue: 1,
 				PrefetchCount:   10,
 				Service:         testServiceName,
-				EagerStart:      tt.eagerStart,
 			}, testutil.NewMockLogger())
 
 			consumer.Register("test-queue", func(ctx context.Context, delivery amqp.Delivery) error {
@@ -144,7 +140,6 @@ func TestMultiTenantConsumer_Stats_Enhanced(t *testing.T) {
 
 			stats := consumer.Stats()
 
-			assert.Equal(t, tt.expectedConnMode, stats.ConnectionMode)
 			assert.Equal(t, tt.expectedKnown, stats.KnownTenants)
 			assert.Equal(t, tt.expectedActive, stats.ActiveTenants)
 			assert.Equal(t, tt.expectedPending, stats.PendingTenants)

--- a/commons/tenant-manager/consumer/multi_tenant_stats.go
+++ b/commons/tenant-manager/consumer/multi_tenant_stats.go
@@ -1,6 +1,6 @@
 package consumer
 
-// Stats returns statistics about the consumer including lazy mode metadata.
+// Stats returns statistics about the consumer.
 func (c *MultiTenantConsumer) Stats() Stats {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -50,19 +50,10 @@ func (c *MultiTenantConsumer) Stats() Stats {
 		TenantIDs:        tenantIDs,
 		RegisteredQueues: queueNames,
 		Closed:           c.closed,
-		ConnectionMode:   connectionMode(c.config.EagerStart),
 		KnownTenants:     len(c.knownTenants),
 		KnownTenantIDs:   knownTenantIDs,
 		PendingTenants:   len(pendingTenantIDs),
 		PendingTenantIDs: pendingTenantIDs,
 		DegradedTenants:  degradedTenantIDs,
 	}
-}
-
-func connectionMode(eagerStart bool) string {
-	if eagerStart {
-		return "eager"
-	}
-
-	return "lazy"
 }

--- a/commons/tenant-manager/consumer/multi_tenant_sync.go
+++ b/commons/tenant-manager/consumer/multi_tenant_sync.go
@@ -26,7 +26,7 @@ func buildActiveTenantsKey(env, service string) string {
 }
 
 // eagerStartKnownTenants starts consumers for all known tenants.
-// Called during Run() when EagerStart is true and tenants were discovered.
+// Called during Run() and when new tenants are discovered during sync.
 func (c *MultiTenantConsumer) eagerStartKnownTenants(ctx context.Context) {
 	c.mu.RLock()
 
@@ -45,8 +45,8 @@ func (c *MultiTenantConsumer) eagerStartKnownTenants(ctx context.Context) {
 }
 
 // discoverTenants fetches tenant IDs and populates knownTenants without starting consumers.
-// This is the lazy mode discovery step: it records which tenants exist but defers consumer
-// creation to background sync or on-demand triggers. Failures are logged as warnings
+// This is the initial discovery step at startup. Actual consumer spawning is handled by
+// eagerStartKnownTenants() after discovery completes. Failures are logged as warnings
 // (soft failure) and do not propagate errors to the caller.
 // A short timeout is applied to avoid blocking startup on unresponsive infrastructure.
 func (c *MultiTenantConsumer) discoverTenants(ctx context.Context) {
@@ -85,7 +85,7 @@ func (c *MultiTenantConsumer) discoverTenants(ctx context.Context) {
 		c.knownTenants[id] = true
 	}
 
-	logger.InfofCtx(ctx, "discovered %d tenants (lazy mode, no consumers started)", len(tenantIDs))
+	logger.InfofCtx(ctx, "discovered %d tenants", len(tenantIDs))
 }
 
 // syncActiveTenants periodically syncs the tenant list.
@@ -137,8 +137,7 @@ func (c *MultiTenantConsumer) runSyncIteration(ctx context.Context) {
 }
 
 // syncTenants fetches tenant IDs and updates the known tenant registry.
-// In lazy mode, new tenants are added to knownTenants but consumers are NOT started.
-// Consumer spawning is deferred to on-demand triggers (e.g., ensureConsumerStarted).
+// New tenants are added to knownTenants and consumers are started immediately.
 // Tenants missing from the fetched list are retained in knownTenants for up to
 // absentSyncsBeforeRemoval consecutive syncs; only after that threshold are they
 // removed from knownTenants and any active consumers stopped. This avoids purging
@@ -190,24 +189,17 @@ func (c *MultiTenantConsumer) syncTenants(ctx context.Context) error {
 	c.closeRemovedTenantConnections(ctx, removedTenants, logger)
 
 	if len(newTenants) > 0 {
-		if c.config.EagerStart {
-			logger.InfofCtx(ctx, "discovered %d new tenants (eager mode, starting consumers): %v",
-				len(newTenants), newTenants)
-		} else {
-			logger.InfofCtx(ctx, "discovered %d new tenants (lazy mode, consumers deferred): %v",
-				len(newTenants), newTenants)
-		}
+		logger.InfofCtx(ctx, "discovered %d new tenants (starting consumers): %v",
+			len(newTenants), newTenants)
 	}
 
 	logger.InfofCtx(ctx, "sync complete: %d known, %d active, %d discovered, %d removed",
 		knownCount, activeCount, len(newTenants), len(removedTenants))
 
-	// Eager mode: start consumers for newly discovered tenants.
+	// Start consumers for newly discovered tenants.
 	// ensureConsumerStarted is called outside the lock (already unlocked above).
-	if c.config.EagerStart && len(newTenants) > 0 {
-		for _, tenantID := range newTenants {
-			c.ensureConsumerStarted(ctx, tenantID)
-		}
+	for _, tenantID := range newTenants {
+		c.ensureConsumerStarted(ctx, tenantID)
 	}
 
 	return nil

--- a/commons/tenant-manager/consumer/multi_tenant_sync_test.go
+++ b/commons/tenant-manager/consumer/multi_tenant_sync_test.go
@@ -21,7 +21,6 @@ func TestMultiTenantConsumer_SyncTenants_EagerModeStartsNewTenant(t *testing.T) 
 		WorkersPerQueue: 1,
 		PrefetchCount:   10,
 		Service:         testServiceName,
-		EagerStart:      true,
 	}, testutil.NewMockLogger())
 	defer func() { require.NoError(t, consumer.Close()) }()
 

--- a/commons/tenant-manager/consumer/multi_tenant_test.go
+++ b/commons/tenant-manager/consumer/multi_tenant_test.go
@@ -154,14 +154,13 @@ const testServiceName = "test-service"
 // This matches the key that fetchTenantIDs will read from when Environment is empty.
 var testActiveTenantsKey = buildActiveTenantsKey("", testServiceName)
 
-// maxRunDuration is the maximum time Run() is allowed to take in lazy mode.
+// maxRunDuration is the maximum time Run() is allowed to take.
 // The requirement specifies <1 second. We use 1 second as the hard deadline.
 const maxRunDuration = 1 * time.Second
 
-// TestMultiTenantConsumer_Run_LazyMode validates that Run() completes within 1 second,
-// returns nil error (soft failure), populates knownTenants, and does NOT start consumers.
-// Covers: AC-F1, AC-F2, AC-F3, AC-F4, AC-F5, AC-F6, AC-O3, AC-Q1
-func TestMultiTenantConsumer_Run_LazyMode(t *testing.T) {
+// TestMultiTenantConsumer_Run_EagerMode validates that Run() completes within 1 second,
+// returns nil error (soft failure), and populates knownTenants.
+func TestMultiTenantConsumer_Run_EagerMode(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -188,7 +187,7 @@ func TestMultiTenantConsumer_Run_LazyMode(t *testing.T) {
 			apiTenants:               nil,
 			expectedKnownTenantCount: 100,
 			expectError:              false,
-			expectConsumersStarted:   false,
+			expectConsumersStarted:   true,
 		},
 		{
 			name:                     "returns_within_1s_with_500_tenants_from_Tenant_Manager_API",
@@ -196,7 +195,7 @@ func TestMultiTenantConsumer_Run_LazyMode(t *testing.T) {
 			apiTenants:               makeTenantSummaries(500),
 			expectedKnownTenantCount: 500,
 			expectError:              false,
-			expectConsumersStarted:   false,
+			expectConsumersStarted:   true,
 		},
 		{
 			name:                     "returns_nil_error_when_both_Redis_and_API_are_down",
@@ -222,7 +221,7 @@ func TestMultiTenantConsumer_Run_LazyMode(t *testing.T) {
 			apiTenants:               nil,
 			expectedKnownTenantCount: 1,
 			expectError:              false,
-			expectConsumersStarted:   false,
+			expectConsumersStarted:   true,
 		},
 		// Edge case: Redis empty but API returns tenants (fallback path)
 		{
@@ -231,7 +230,7 @@ func TestMultiTenantConsumer_Run_LazyMode(t *testing.T) {
 			apiTenants:               makeTenantSummaries(3),
 			expectedKnownTenantCount: 3,
 			expectError:              false,
-			expectConsumersStarted:   false,
+			expectConsumersStarted:   true,
 		},
 		// Edge case: Redis down but API is up. Discovery timeout (500ms) may
 		// be consumed by the Redis connection attempt, so API fallback may not
@@ -303,9 +302,8 @@ func TestMultiTenantConsumer_Run_LazyMode(t *testing.T) {
 				consumer.config.Service = "test-service"
 			}
 
-			// Register a handler (to verify it is NOT consumed from during Run)
+			// Register a handler
 			consumer.Register("test-queue", func(ctx context.Context, delivery amqp.Delivery) error {
-				t.Error("handler should not be called during Run() in lazy mode")
 				return nil
 			})
 
@@ -319,15 +317,15 @@ func TestMultiTenantConsumer_Run_LazyMode(t *testing.T) {
 
 			// ASSERTION 1: Run() completes within maxRunDuration
 			assert.Less(t, elapsed, maxRunDuration,
-				"Run() must complete within %s in lazy mode, took %s", maxRunDuration, elapsed)
+				"Run() must complete within %s, took %s", maxRunDuration, elapsed)
 
 			// ASSERTION 2: Run() returns nil error (even on discovery failure)
 			if !tt.expectError {
 				assert.NoError(t, err,
-					"Run() must return nil error in lazy mode (soft failure on discovery)")
+					"Run() must return nil error (soft failure on discovery)")
 			}
 
-			// ASSERTION 3: knownTenants is populated (NOT tenants which holds cancel funcs)
+			// ASSERTION 3: knownTenants is populated
 			consumer.mu.RLock()
 			knownCount := len(consumer.knownTenants)
 			consumersStarted := len(consumer.tenants)
@@ -337,11 +335,13 @@ func TestMultiTenantConsumer_Run_LazyMode(t *testing.T) {
 				"knownTenants should have %d entries after Run(), got %d",
 				tt.expectedKnownTenantCount, knownCount)
 
-			// ASSERTION 4: No consumers started during Run() (lazy mode = no startTenantConsumer calls)
-			if !tt.expectConsumersStarted {
+			// ASSERTION 4: Consumers started for discovered tenants (eager mode)
+			if tt.expectConsumersStarted {
+				assert.Greater(t, consumersStarted, 0,
+					"consumers should be started eagerly for discovered tenants")
+			} else {
 				assert.Equal(t, 0, consumersStarted,
-					"no goroutines should call startTenantConsumer() during Run(), but %d consumers are active",
-					consumersStarted)
+					"no consumers should be started when no tenants discovered")
 			}
 
 			// Cleanup
@@ -453,8 +453,7 @@ func TestMultiTenantConsumer_DiscoverTenants_ReuseFetchTenantIDs(t *testing.T) {
 }
 
 // TestMultiTenantConsumer_Run_StartupLog verifies that Run() produces a log message
-// containing "connection_mode=lazy" during startup.
-// Covers: AC-T3
+// containing "connection_mode=eager" during startup.
 func TestMultiTenantConsumer_Run_StartupLog(t *testing.T) {
 	t.Parallel()
 
@@ -463,8 +462,8 @@ func TestMultiTenantConsumer_Run_StartupLog(t *testing.T) {
 		expectedLogPart string
 	}{
 		{
-			name:            "startup_log_contains_connection_mode_lazy",
-			expectedLogPart: "connection_mode=lazy",
+			name:            "startup_log_contains_connection_mode_eager",
+			expectedLogPart: "connection_mode=eager",
 		},
 	}
 
@@ -497,9 +496,9 @@ func TestMultiTenantConsumer_Run_StartupLog(t *testing.T) {
 			ctx = libCommons.ContextWithLogger(ctx, logger)
 
 			err := consumer.Run(ctx)
-			assert.NoError(t, err, "Run() should return nil in lazy mode")
+			assert.NoError(t, err, "Run() should return nil")
 
-			// Verify the startup log contains connection_mode=lazy
+			// Verify the startup log contains connection_mode=eager
 			assert.True(t, logger.ContainsSubstring(tt.expectedLogPart),
 				"startup log must contain %q, got messages: %v",
 				tt.expectedLogPart, logger.GetMessages())
@@ -551,9 +550,9 @@ func TestMultiTenantConsumer_Run_BackgroundSyncStarts(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			// Run() should return immediately (lazy mode)
+			// Run() should return quickly
 			err := consumer.Run(ctx)
-			require.NoError(t, err, "Run() should succeed in lazy mode")
+			require.NoError(t, err, "Run() should succeed")
 
 			// After Run, add tenants to Redis - the sync loop should pick them up
 			mr.SAdd(testActiveTenantsKey, tt.tenantToAdd)
@@ -996,7 +995,7 @@ func TestMultiTenantConsumer_Stats(t *testing.T) {
 			stats := consumer.Stats()
 
 			assert.Equal(t, 0, stats.ActiveTenants,
-				"no tenants should be active (lazy mode, no startTenantConsumer called)")
+				"no tenants should be active (no Run() called)")
 			assert.Equal(t, len(tt.registerQueues), len(stats.RegisteredQueues),
 				"registered queues count should match")
 			assert.Equal(t, tt.expectClosed, stats.Closed, "closed flag mismatch")
@@ -1161,45 +1160,36 @@ func TestMultiTenantConsumer_SyncTenants_RemovesTenants(t *testing.T) {
 	}
 }
 
-// TestMultiTenantConsumer_SyncTenants_LazyMode verifies that syncTenants() populates
-// knownTenants for new tenants WITHOUT starting consumer goroutines (lazy mode behavior).
-// In lazy mode, consumers are spawned on-demand (T-002), not during sync.
-// Covers: T-005 AC-F1, AC-F2, AC-T3
-func TestMultiTenantConsumer_SyncTenants_LazyMode(t *testing.T) {
+// TestMultiTenantConsumer_SyncTenants_EagerMode verifies that syncTenants() populates
+// knownTenants for new tenants AND starts consumer goroutines eagerly.
+func TestMultiTenantConsumer_SyncTenants_EagerMode(t *testing.T) {
 	tests := []struct {
-		name                  string
-		initialRedisTenants   []string
-		newRedisTenants       []string
-		expectedKnownCount    int
-		expectedConsumerCount int
+		name                string
+		initialRedisTenants []string
+		newRedisTenants     []string
+		expectedKnownCount  int
+		expectConsumers     bool
 	}{
 		{
-			name:                  "new_tenants_added_to_knownTenants_only_not_activeTenants",
-			initialRedisTenants:   []string{},
-			newRedisTenants:       []string{"tenant-a", "tenant-b", "tenant-c"},
-			expectedKnownCount:    3,
-			expectedConsumerCount: 0,
+			name:                "new_tenants_added_and_consumers_started",
+			initialRedisTenants: []string{},
+			newRedisTenants:     []string{"tenant-a", "tenant-b", "tenant-c"},
+			expectedKnownCount:  3,
+			expectConsumers:     true,
 		},
 		{
-			name:                  "sync_discovers_100_tenants_without_starting_consumers",
-			initialRedisTenants:   []string{},
-			newRedisTenants:       generateTenantIDs(100),
-			expectedKnownCount:    100,
-			expectedConsumerCount: 0,
+			name:                "sync_discovers_tenants_and_starts_consumers",
+			initialRedisTenants: []string{},
+			newRedisTenants:     generateTenantIDs(10),
+			expectedKnownCount:  10,
+			expectConsumers:     true,
 		},
 		{
-			name:                  "sync_adds_incremental_tenants_without_starting_consumers",
-			initialRedisTenants:   []string{"existing-tenant"},
-			newRedisTenants:       []string{"existing-tenant", "new-tenant-1", "new-tenant-2"},
-			expectedKnownCount:    3,
-			expectedConsumerCount: 0,
-		},
-		{
-			name:                  "sync_with_zero_tenants_starts_no_consumers",
-			initialRedisTenants:   []string{},
-			newRedisTenants:       []string{},
-			expectedKnownCount:    0,
-			expectedConsumerCount: 0,
+			name:                "sync_with_zero_tenants_starts_no_consumers",
+			initialRedisTenants: []string{},
+			newRedisTenants:     []string{},
+			expectedKnownCount:  0,
+			expectConsumers:     false,
 		},
 	}
 
@@ -1220,13 +1210,15 @@ func TestMultiTenantConsumer_SyncTenants_LazyMode(t *testing.T) {
 				Service:         "test-service",
 			}, testutil.NewMockLogger())
 
-			// Register a handler so startTenantConsumer would have something to consume
+			// Register a handler so startTenantConsumer has something to consume
 			consumer.Register("test-queue", func(ctx context.Context, delivery amqp.Delivery) error {
-				t.Error("handler must not be called during syncTenants in lazy mode")
 				return nil
 			})
 
-			ctx := context.Background()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			consumer.parentCtx = ctx
 
 			// Initial discovery (populates knownTenants only)
 			consumer.discoverTenants(ctx)
@@ -1237,7 +1229,7 @@ func TestMultiTenantConsumer_SyncTenants_LazyMode(t *testing.T) {
 				mr.SAdd(testActiveTenantsKey, id)
 			}
 
-			// Run syncTenants - should populate knownTenants but NOT start consumers
+			// Run syncTenants - should populate knownTenants and start consumers
 			err := consumer.syncTenants(ctx)
 			assert.NoError(t, err, "syncTenants should not return error")
 
@@ -1251,10 +1243,17 @@ func TestMultiTenantConsumer_SyncTenants_LazyMode(t *testing.T) {
 				"syncTenants must populate knownTenants (expected %d, got %d)",
 				tt.expectedKnownCount, knownCount)
 
-			// ASSERTION 2: No consumer goroutines started (lazy mode)
-			assert.Equal(t, tt.expectedConsumerCount, consumerCount,
-				"syncTenants must NOT start consumers in lazy mode (expected %d active consumers, got %d)",
-				tt.expectedConsumerCount, consumerCount)
+			// ASSERTION 2: Consumers started for discovered tenants
+			if tt.expectConsumers {
+				assert.Greater(t, consumerCount, 0,
+					"syncTenants should start consumers eagerly for discovered tenants")
+			} else {
+				assert.Equal(t, 0, consumerCount,
+					"no consumers expected when no tenants discovered")
+			}
+
+			cancel()
+			consumer.Close()
 		})
 	}
 }
@@ -2035,63 +2034,6 @@ func TestMultiTenantConsumer_EnsureConsumerStarted_MultipleTenants(t *testing.T)
 	}
 }
 
-// TestMultiTenantConsumer_EnsureConsumerStarted_PublicAPI verifies the public
-// EnsureConsumerStarted method delegates correctly to the internal method.
-func TestMultiTenantConsumer_EnsureConsumerStarted_PublicAPI(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		tenantID string
-	}{
-		{
-			name:     "public_API_spawns_consumer",
-			tenantID: "tenant-public",
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			_, redisClient := setupMiniredis(t)
-
-			consumer := NewMultiTenantConsumer(dummyRabbitMQManager(), redisClient, MultiTenantConfig{
-				SyncInterval:    30 * time.Second,
-				WorkersPerQueue: 1,
-				PrefetchCount:   10,
-			}, testutil.NewMockLogger())
-
-			consumer.Register("test-queue", func(ctx context.Context, delivery amqp.Delivery) error {
-				return nil
-			})
-
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-
-			consumer.parentCtx = ctx
-
-			// Add tenant to knownTenants (normally done by discoverTenants)
-			consumer.mu.Lock()
-			consumer.knownTenants[tt.tenantID] = true
-			consumer.mu.Unlock()
-
-			// Use public API
-			consumer.EnsureConsumerStarted(ctx, tt.tenantID)
-
-			consumer.mu.RLock()
-			_, exists := consumer.tenants[tt.tenantID]
-			consumer.mu.RUnlock()
-
-			assert.True(t, exists, "public API should spawn consumer for tenant %q", tt.tenantID)
-
-			cancel()
-			consumer.Close()
-		})
-	}
-}
-
 // ---------------------
 // T-004: Connection Failure Resilience Tests
 // ---------------------
@@ -2186,7 +2128,7 @@ func TestMultiTenantConsumer_StructuredLogEvents(t *testing.T) {
 		{
 			name:            "run_logs_connection_mode",
 			operation:       "run",
-			expectedLogPart: "connection_mode=lazy",
+			expectedLogPart: "connection_mode=eager",
 		},
 		{
 			name:            "discover_logs_tenant_count",
@@ -2265,7 +2207,7 @@ func TestMultiTenantConsumer_StructuredLogEvents(t *testing.T) {
 	}
 }
 
-// BenchmarkMultiTenantConsumer_Run_Startup measures startup time of Run() in lazy mode.
+// BenchmarkMultiTenantConsumer_Run_Startup measures startup time of Run().
 // Target: <1 second for all tenant configurations.
 // Covers: AC-Q2
 func BenchmarkMultiTenantConsumer_Run_Startup(b *testing.B) {

--- a/commons/tenant-manager/middleware/multi_pool.go
+++ b/commons/tenant-manager/middleware/multi_pool.go
@@ -22,14 +22,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// ConsumerTrigger triggers on-demand consumer spawning for lazy mode.
-// Implementations should ensure idempotent behavior: calling EnsureConsumerStarted
-// multiple times for the same tenantID must be safe and return quickly after the
-// first invocation.
-type ConsumerTrigger interface {
-	EnsureConsumerStarted(ctx context.Context, tenantID string)
-}
-
 // ErrorMapper converts tenant-manager errors into Fiber HTTP responses.
 // If nil, the default error mapping is used.
 type ErrorMapper func(c *fiber.Ctx, err error, tenantID string) error
@@ -49,16 +41,15 @@ type MultiPoolOption func(*MultiPoolMiddleware)
 
 // MultiPoolMiddleware routes requests to module-specific tenant pools
 // based on URL path matching. It handles JWT extraction, pool resolution,
-// connection injection, error mapping, and consumer triggering.
+// connection injection, and error mapping.
 type MultiPoolMiddleware struct {
-	routes          []*PoolRoute
-	defaultRoute    *PoolRoute
-	publicPaths     []string
-	consumerTrigger ConsumerTrigger
-	crossModule     bool
-	errorMapper     ErrorMapper
-	logger          *logcompat.Logger
-	enabled         bool
+	routes       []*PoolRoute
+	defaultRoute *PoolRoute
+	publicPaths  []string
+	crossModule  bool
+	errorMapper  ErrorMapper
+	logger       *logcompat.Logger
+	enabled      bool
 }
 
 // WithRoute registers a path-based route mapping URL prefixes to a module's
@@ -94,15 +85,6 @@ func WithDefaultRoute(module string, pgPool *tmpostgres.Manager, mongoPool *tmmo
 func WithPublicPaths(paths ...string) MultiPoolOption {
 	return func(m *MultiPoolMiddleware) {
 		m.publicPaths = append(m.publicPaths, paths...)
-	}
-}
-
-// WithConsumerTrigger sets a ConsumerTrigger that is invoked after tenant ID
-// extraction. This enables lazy consumer spawning in multi-tenant messaging
-// architectures.
-func WithConsumerTrigger(ct ConsumerTrigger) MultiPoolOption {
-	return func(m *MultiPoolMiddleware) {
-		m.consumerTrigger = ct
 	}
 }
 
@@ -221,13 +203,7 @@ func (m *MultiPoolMiddleware) WithTenantDB(c *fiber.Ctx) error {
 		return m.handleTenantDBError(c, err, tenantID)
 	}
 
-	// Step 8: Trigger consumer AFTER successful resolution.
-	// Only trigger for tenants whose connections are confirmed resolvable.
-	if m.consumerTrigger != nil {
-		m.consumerTrigger.EnsureConsumerStarted(ctx, tenantID)
-	}
-
-	// Step 9: Update context
+	// Step 8: Update context
 	c.SetUserContext(ctx)
 
 	logger.InfofCtx(ctx, "multi-pool connections injected: tenantID=%s, module=%s", tenantID, route.module)

--- a/commons/tenant-manager/middleware/multi_pool_test.go
+++ b/commons/tenant-manager/middleware/multi_pool_test.go
@@ -5,12 +5,10 @@
 package middleware
 
 import (
-	"context"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 
 	"github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/client"
@@ -37,38 +35,6 @@ func newSingleTenantManagers() (*tmpostgres.Manager, *tmmongo.Manager) {
 	return tmpostgres.NewManager(nil, "ledger"), tmmongo.NewManager(nil, "ledger")
 }
 
-// mockConsumerTrigger implements ConsumerTrigger for testing.
-type mockConsumerTrigger struct {
-	mu        sync.Mutex
-	called    bool
-	tenantIDs []string
-}
-
-func (m *mockConsumerTrigger) EnsureConsumerStarted(_ context.Context, tenantID string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	m.called = true
-	m.tenantIDs = append(m.tenantIDs, tenantID)
-}
-
-func (m *mockConsumerTrigger) wasCalled() bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	return m.called
-}
-
-func (m *mockConsumerTrigger) getCalledTenantIDs() []string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	result := make([]string, len(m.tenantIDs))
-	copy(result, m.tenantIDs)
-
-	return result
-}
-
 func TestNewMultiPoolMiddleware(t *testing.T) {
 	t.Parallel()
 
@@ -82,7 +48,6 @@ func TestNewMultiPoolMiddleware(t *testing.T) {
 		assert.Empty(t, mid.routes)
 		assert.Nil(t, mid.defaultRoute)
 		assert.Equal(t, []string{"/healthz", "/readyz", "/livez", "/health"}, mid.publicPaths)
-		assert.Nil(t, mid.consumerTrigger)
 		assert.False(t, mid.crossModule)
 		assert.Nil(t, mid.errorMapper)
 		assert.Nil(t, mid.logger)
@@ -137,7 +102,6 @@ func TestNewMultiPoolMiddleware(t *testing.T) {
 		t.Parallel()
 
 		pgPool, mongoPool := newMultiPoolTestManagers(t, "http://localhost:8080")
-		trigger := &mockConsumerTrigger{}
 		mapper := func(_ *fiber.Ctx, _ error, _ string) error { return nil }
 
 		mid := NewMultiPoolMiddleware(
@@ -145,7 +109,6 @@ func TestNewMultiPoolMiddleware(t *testing.T) {
 			WithRoute([]string{"/v1/accounts"}, "account", pgPool, nil),
 			WithDefaultRoute("ledger", pgPool, mongoPool),
 			WithPublicPaths("/health", "/ready"),
-			WithConsumerTrigger(trigger),
 			WithCrossModuleInjection(),
 			WithErrorMapper(mapper),
 		)
@@ -154,7 +117,6 @@ func TestNewMultiPoolMiddleware(t *testing.T) {
 		assert.Len(t, mid.routes, 2)
 		assert.NotNil(t, mid.defaultRoute)
 		assert.Equal(t, []string{"/healthz", "/readyz", "/livez", "/health", "/health", "/ready"}, mid.publicPaths)
-		assert.NotNil(t, mid.consumerTrigger)
 		assert.True(t, mid.crossModule)
 		assert.NotNil(t, mid.errorMapper)
 	})
@@ -605,55 +567,6 @@ func TestMultiPoolMiddleware_WithTenantDB_ErrorMapperDelegation(t *testing.T) {
 	assert.Contains(t, string(body), "CUSTOM_ERROR")
 }
 
-func TestMultiPoolMiddleware_WithTenantDB_ConsumerTrigger(t *testing.T) {
-	t.Parallel()
-
-	// Create a mock Tenant Manager server that returns 404 (tenant not found).
-	// The important assertion is that the consumer trigger was called BEFORE
-	// the PG connection resolution attempt.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error":"not found"}`))
-	}))
-	defer server.Close()
-
-	pgPool, _ := newMultiPoolTestManagers(t, server.URL)
-	trigger := &mockConsumerTrigger{}
-
-	mid := NewMultiPoolMiddleware(
-		WithRoute([]string{"/v1/transactions"}, "transaction", pgPool, nil),
-		WithConsumerTrigger(trigger),
-	)
-
-	token := buildTestJWT(t, map[string]any{
-		"sub":      "user-123",
-		"tenantId": "tenant-abc",
-	})
-
-	app := fiber.New()
-	app.Use(simulateAuthMiddleware("user-123"))
-	app.Use(mid.WithTenantDB)
-	app.Get("/v1/transactions", func(c *fiber.Ctx) error {
-		return c.SendString("ok")
-	})
-
-	req := httptest.NewRequest(http.MethodGet, "/v1/transactions", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err := app.Test(req, -1)
-	require.NoError(t, err)
-
-	defer resp.Body.Close()
-
-	// The PG connection will fail (mock returns 404). The consumer trigger is
-	// invoked AFTER successful PG resolution to prevent starting consumers for
-	// suspended/unresolvable tenants (finding 3.5/3.7). Since PG resolution
-	// failed here, the trigger should NOT have been called.
-	assert.False(t, trigger.wasCalled(),
-		"consumer trigger should NOT be called when PG resolution fails")
-	assert.Empty(t, trigger.getCalledTenantIDs())
-}
-
 func TestMultiPoolMiddleware_WithTenantDB_DefaultRouteMatching(t *testing.T) {
 	t.Parallel()
 
@@ -1036,18 +949,6 @@ func TestWithPublicPaths(t *testing.T) {
 	opt2(mid)
 
 	assert.Equal(t, []string{"/health", "/ready", "/version"}, mid.publicPaths)
-}
-
-func TestWithConsumerTrigger(t *testing.T) {
-	t.Parallel()
-
-	trigger := &mockConsumerTrigger{}
-
-	mid := &MultiPoolMiddleware{}
-	opt := WithConsumerTrigger(trigger)
-	opt(mid)
-
-	assert.NotNil(t, mid.consumerTrigger)
 }
 
 func TestWithCrossModuleInjection(t *testing.T) {


### PR DESCRIPTION
## Summary
- Remove lazy consumer mode from `MultiTenantConsumer`; all consumers now start eagerly at discovery and sync time
- Remove public `EnsureConsumerStarted()` method (private `ensureConsumerStarted()` retained for double-check locking)
- Remove `ConsumerTrigger` interface, `WithConsumerTrigger()` option, and consumer trigger invocation from `MultiPoolMiddleware`
- Remove `connectionMode()` helper and `ConnectionMode` field from `Stats` struct
- Mark `EagerStart` config field as deprecated (no-op, retained for backward compatibility)
- Simplify tests: remove lazy-mode parameterized cases, update assertions for eager-only behavior

Closes #349