### PR TITLE
fix(postgres): revert default SSLMode to disable for local dev compatibility

### DIFF
--- a/commons/tenant-manager/postgres/manager.go
+++ b/commons/tenant-manager/postgres/manager.go
@@ -836,7 +836,9 @@ func buildConnectionString(cfg *core.PostgreSQLConfig) (string, error) {
 
 	sslmode := cfg.SSLMode
 	if sslmode == "" {
-		sslmode = "require"
+		// Default is "disable" for local development compatibility.
+		// Production deployments should set SSLMode explicitly in PostgreSQLConfig.
+		sslmode = "disable"
 	}
 
 	connURL := &url.URL{

--- a/commons/tenant-manager/postgres/manager_test.go
+++ b/commons/tenant-manager/postgres/manager_test.go
@@ -166,7 +166,7 @@ func TestBuildConnectionString(t *testing.T) {
 			expected: "postgres://user:pass@localhost:5432/testdb?options=-csearch_path%3Dtenant_abc&sslmode=disable",
 		},
 		{
-			name: "defaults sslmode to require when empty",
+			name: "defaults sslmode to disable when empty",
 			cfg: &core.PostgreSQLConfig{
 				Host:     "localhost",
 				Port:     5432,
@@ -174,7 +174,7 @@ func TestBuildConnectionString(t *testing.T) {
 				Password: "pass",
 				Database: "testdb",
 			},
-			expected: "postgres://user:pass@localhost:5432/testdb?sslmode=require",
+			expected: "postgres://user:pass@localhost:5432/testdb?sslmode=disable",
 		},
 		{
 			name: "uses provided sslmode",


### PR DESCRIPTION
## Summary

- Reverts the default `SSLMode` in `buildConnectionString` from `"require"` back to `"disable"` for local development compatibility.
- Adds comment clarifying that production deployments should set `SSLMode` explicitly in `PostgreSQLConfig`.
- Updates existing test case to verify the new default.

Closes #344