### PR TITLE
fix(client): update tenant-manager endpoint from /services/ to /associations/

### DIFF
--- a/commons/tenant-manager/client/client.go
+++ b/commons/tenant-manager/client/client.go
@@ -431,7 +431,7 @@ func (c *Client) cacheTenantConfig(ctx context.Context, cacheKey string, config 
 }
 
 // GetTenantConfig fetches tenant configuration from the Tenant Manager API.
-// The API endpoint is: GET {baseURL}/v1/tenants/{tenantID}/services/{service}/connections.
+// The API endpoint is: GET {baseURL}/v1/tenants/{tenantID}/associations/{service}/connections.
 // Successful responses are cached unless WithSkipCache is used.
 func (c *Client) GetTenantConfig(ctx context.Context, tenantID, service string, opts ...GetConfigOption) (*core.TenantConfig, error) {
 	if c.httpClient == nil {
@@ -467,7 +467,7 @@ func (c *Client) GetTenantConfig(ctx context.Context, tenantID, service string, 
 	}
 
 	// Build the URL with properly escaped path parameters to prevent path traversal
-	requestURL := fmt.Sprintf("%s/v1/tenants/%s/services/%s/connections",
+	requestURL := fmt.Sprintf("%s/v1/tenants/%s/associations/%s/connections",
 		c.baseURL, url.PathEscape(tenantID), url.PathEscape(service))
 
 	logger.Log(ctx, libLog.LevelInfo, "fetching tenant config",

--- a/commons/tenant-manager/client/client_test.go
+++ b/commons/tenant-manager/client/client_test.go
@@ -175,7 +175,7 @@ func TestClient_GetTenantConfig(t *testing.T) {
 		config := newTestTenantConfig()
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "/v1/tenants/tenant-123/services/ledger/connections", r.URL.Path)
+			assert.Equal(t, "/v1/tenants/tenant-123/associations/ledger/connections", r.URL.Path)
 
 			w.Header().Set("Content-Type", "application/json")
 			require.NoError(t, json.NewEncoder(w).Encode(config))


### PR DESCRIPTION
## Summary

Tenant-manager consolidated all tenant-scoped routes under `/associations/` (LerianStudio/tenant-manager#134). The lib-commons client still called the old `/services/` path, causing 404 → "tenant not found" errors.

## Change

- `client.go` line 470: `/v1/tenants/{id}/services/{svc}/connections` → `/v1/tenants/{id}/associations/{svc}/connections`
- Test assertion updated to match

## Test plan

- [x] `go test ./commons/tenant-manager/... -count=1` — all pass