### PR TITLE
fix(otel): normalize OTEL endpoint env vars to prevent SDK parse errors

### DIFF
--- a/commons/opentelemetry/otel.go
+++ b/commons/opentelemetry/otel.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -99,6 +100,7 @@ func NewTelemetry(cfg TelemetryConfig) (*Telemetry, error) {
 	}
 
 	normalizeEndpoint(&cfg)
+	normalizeEndpointEnvVars()
 
 	if cfg.EnableTelemetry && strings.TrimSpace(cfg.CollectorExporterEndpoint) == "" {
 		return handleEmptyEndpoint(cfg)
@@ -140,6 +142,25 @@ func normalizeEndpoint(cfg *TelemetryConfig) {
 	default:
 		// No scheme — assume insecure (common in k8s internal comms).
 		cfg.InsecureExporter = true
+	}
+}
+
+// normalizeEndpointEnvVars ensures OTEL exporter endpoint environment variables
+// contain a URL scheme. The OTEL SDK's envconfig reads these via url.Parse(),
+// which fails on bare "host:port" values. Adding "http://" prevents noisy
+// "parse url" errors from the SDK's internal logger.
+func normalizeEndpointEnvVars() {
+	for _, key := range []string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+	} {
+		v := strings.TrimSpace(os.Getenv(key))
+		if v == "" || strings.HasPrefix(v, "http://") || strings.HasPrefix(v, "https://") {
+			continue
+		}
+
+		_ = os.Setenv(key, "http://"+v)
 	}
 }
 

--- a/commons/opentelemetry/otel_test.go
+++ b/commons/opentelemetry/otel_test.go
@@ -4,6 +4,7 @@ package opentelemetry
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -193,6 +194,89 @@ func TestNewTelemetry_EndpointNormalization(t *testing.T) {
 			assert.Equal(t, tt.wantInsecure, tl.InsecureExporter,
 				"InsecureExporter should be inferred from scheme")
 		})
+	}
+}
+
+// ===========================================================================
+// 1c. Endpoint environment variable normalization
+// ===========================================================================
+
+func TestNormalizeEndpointEnvVars(t *testing.T) {
+	envKeys := []string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+	}
+
+	tests := []struct {
+		name     string
+		value    string
+		set      bool
+		expected string
+	}{
+		{
+			name:     "bare host:port gets http scheme",
+			value:    "10.10.0.202:4317",
+			set:      true,
+			expected: "http://10.10.0.202:4317",
+		},
+		{
+			name:     "hostname:port gets http scheme",
+			value:    "otel-collector:4317",
+			set:      true,
+			expected: "http://otel-collector:4317",
+		},
+		{
+			name:     "http scheme preserved",
+			value:    "http://otel-collector:4317",
+			set:      true,
+			expected: "http://otel-collector:4317",
+		},
+		{
+			name:     "https scheme preserved",
+			value:    "https://otel-collector:4317",
+			set:      true,
+			expected: "https://otel-collector:4317",
+		},
+		{
+			name:     "whitespace trimmed before adding scheme",
+			value:    "  10.10.0.202:4317  ",
+			set:      true,
+			expected: "http://10.10.0.202:4317",
+		},
+		{
+			name:     "empty value skipped",
+			value:    "",
+			set:      true,
+			expected: "",
+		},
+		{
+			name:     "whitespace-only value skipped",
+			value:    "   ",
+			set:      true,
+			expected: "   ",
+		},
+		{
+			name:     "unset env var skipped",
+			value:    "",
+			set:      false,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		for _, key := range envKeys {
+			t.Run(tt.name+"/"+key, func(t *testing.T) {
+				if tt.set {
+					t.Setenv(key, tt.value)
+				}
+
+				normalizeEndpointEnvVars()
+
+				got := os.Getenv(key)
+				assert.Equal(t, tt.expected, got)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `normalizeEndpointEnvVars()` that prepends `http://` to `OTEL_EXPORTER_OTLP_*_ENDPOINT` env vars when they contain bare `host:port` without a scheme
- Prevents the OTEL SDK's internal `url.Parse()` from logging noisy `"parse url"` errors
- Complements the existing `normalizeEndpoint()` which only handled the programmatic `CollectorExporterEndpoint` config field

## Problem

The OTEL Go SDK (v1.42.0) reads endpoint env vars internally via `envconfig.WithURL()` → `url.Parse()`. When the env var contains `host:port` without a scheme (e.g. `10.10.0.202:4317`), Go's URL parser fails:

```
"msg"="parse url" "error"="parse \"10.10.0.202:4317\": first path segment in URL cannot contain colon"
```

This happens independently of the programmatic `WithEndpoint()` path, which PR #362 already fixed. The SDK reads env vars **before** applying programmatic options, so bare `host:port` in env vars still caused the error.

## Root Cause

The OTEL SDK's `envconfig.go` (lines 93-104) uses `url.Parse()` to read `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, and `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`. The error appears twice per startup (once for trace exporter, once for metric exporter).

## Test plan

- [x] 8 table-driven test cases × 3 env var keys = 24 subtests covering: bare host:port, hostname:port, http preserved, https preserved, whitespace trimming, empty value, whitespace-only, unset env var
- [x] All existing tests pass
- [x] `go build ./commons/opentelemetry/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)