### PR TITLE
fix(zap): use ISO8601 timestamp format instead of Unix epoch

### DIFF
--- a/commons/zap/injector.go
+++ b/commons/zap/injector.go
@@ -119,6 +119,7 @@ func buildConfigByEnvironment(environment Environment) zap.Config {
 		cfg := zap.NewDevelopmentConfig()
 		cfg.Encoding = encoding
 		cfg.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+		cfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 
 		if encoding == encodingConsole {
 			cfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
@@ -130,6 +131,7 @@ func buildConfigByEnvironment(environment Environment) zap.Config {
 	cfg := zap.NewProductionConfig()
 	cfg.Encoding = encoding
 	cfg.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+	cfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 
 	return cfg
 }


### PR DESCRIPTION
## Summary

Change log timestamp format from Unix epoch floats to ISO8601 for human readability.

**Before:** `"ts": 1774204208.773082`
**After:** `"ts": "2026-03-22T15:30:08.773Z"`

Applied to both development and production encoder configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)