### PR TITLE
feat(consumer/postgres): propagate CacheTTL and apply statementTimeout with change detection

### DIFF
--- a/commons/tenant-manager/consumer/multi_tenant.go
+++ b/commons/tenant-manager/consumer/multi_tenant.go
@@ -74,6 +74,11 @@ type MultiTenantConfig struct {
 	// Default: false
 	AllowInsecureHTTP bool
 
+	// CacheTTL is the TTL for the internal tenant config cache used by the consumer's
+	// HTTP client. When zero, the client's default (1 hour) is used.
+	// Recommended: match the MULTI_TENANT_CACHE_TTL_SEC env var from the consuming service.
+	CacheTTL time.Duration
+
 	// Deprecated: EagerStart is ignored. Consumers are always started eagerly.
 	// This field is retained only for backward compatibility with existing configs;
 	// setting it has no effect. It will be removed in a future major version.
@@ -209,6 +214,10 @@ func NewMultiTenantConsumerWithError(
 
 	if config.AllowInsecureHTTP {
 		clientOpts = append(clientOpts, client.WithAllowInsecureHTTP())
+	}
+
+	if config.CacheTTL > 0 {
+		clientOpts = append(clientOpts, client.WithCacheTTL(config.CacheTTL))
 	}
 
 	pmClient, err := client.NewClient(config.MultiTenantURL, consumer.logger.Base(), clientOpts...)

--- a/commons/tenant-manager/consumer/multi_tenant.go
+++ b/commons/tenant-manager/consumer/multi_tenant.go
@@ -179,6 +179,10 @@ func NewMultiTenantConsumerWithError(
 		return nil, errors.New("consumer.NewMultiTenantConsumerWithError: Service must not be empty")
 	}
 
+	if config.CacheTTL < 0 {
+		return nil, fmt.Errorf("consumer.NewMultiTenantConsumerWithError: CacheTTL must be non-negative, got %v", config.CacheTTL)
+	}
+
 	// Guard against nil logger to prevent panics downstream
 	if logger == nil {
 		logger = libLog.NewNop()

--- a/commons/tenant-manager/consumer/multi_tenant_test.go
+++ b/commons/tenant-manager/consumer/multi_tenant_test.go
@@ -816,7 +816,53 @@ func TestMultiTenantConsumer_CacheTTLPropagation(t *testing.T) {
 			assert.NotNil(t, consumer.pmClient, "pmClient should be created")
 			assert.Equal(t, tt.cacheTTL, consumer.config.CacheTTL, "CacheTTL should be preserved in config")
 
-			_ = consumer.Close()
+			// NOTE: The client's cacheTTL field is unexported, so we cannot directly
+			// inspect it. CacheTTL is propagated to the internal client via
+			// client.WithCacheTTL at construction time. This test verifies that the
+			// consumer is created successfully with the CacheTTL value and that
+			// the pmClient is non-nil, confirming the option was accepted.
+
+			require.NoError(t, consumer.Close())
+		})
+	}
+}
+
+// TestMultiTenantConsumer_CacheTTL_NegativeRejected verifies that negative CacheTTL
+// values are rejected by NewMultiTenantConsumerWithError.
+func TestMultiTenantConsumer_CacheTTL_NegativeRejected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cacheTTL time.Duration
+	}{
+		{
+			name:     "rejects_negative_CacheTTL",
+			cacheTTL: -1 * time.Second,
+		},
+		{
+			name:     "rejects_large_negative_CacheTTL",
+			cacheTTL: -10 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config := MultiTenantConfig{
+				MultiTenantURL:    "http://tenant-manager:4003",
+				ServiceAPIKey:     "test-key",
+				Service:           "ledger",
+				AllowInsecureHTTP: true,
+				CacheTTL:          tt.cacheTTL,
+			}
+
+			consumer, err := NewMultiTenantConsumerWithError(dummyRabbitMQManager(), config, testutil.NewMockLogger())
+			require.Error(t, err)
+			assert.Nil(t, consumer)
+			assert.Contains(t, err.Error(), "CacheTTL must be non-negative")
 		})
 	}
 }

--- a/commons/tenant-manager/consumer/multi_tenant_test.go
+++ b/commons/tenant-manager/consumer/multi_tenant_test.go
@@ -774,6 +774,53 @@ func TestMultiTenantConsumer_NewWithZeroConfig(t *testing.T) {
 	}
 }
 
+// TestMultiTenantConsumer_CacheTTLPropagation verifies that the CacheTTL config field
+// is propagated to the underlying HTTP client via client.WithCacheTTL.
+func TestMultiTenantConsumer_CacheTTLPropagation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cacheTTL time.Duration
+	}{
+		{
+			name:     "zero_CacheTTL_uses_client_default",
+			cacheTTL: 0,
+		},
+		{
+			name:     "positive_CacheTTL_is_propagated",
+			cacheTTL: 5 * time.Minute,
+		},
+		{
+			name:     "large_CacheTTL_is_propagated",
+			cacheTTL: 2 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config := MultiTenantConfig{
+				MultiTenantURL:    "http://tenant-manager:4003",
+				ServiceAPIKey:     "test-key",
+				Service:           "ledger",
+				AllowInsecureHTTP: true,
+				CacheTTL:          tt.cacheTTL,
+			}
+
+			consumer, err := NewMultiTenantConsumerWithError(dummyRabbitMQManager(), config, testutil.NewMockLogger())
+			require.NoError(t, err)
+			assert.NotNil(t, consumer)
+			assert.NotNil(t, consumer.pmClient, "pmClient should be created")
+			assert.Equal(t, tt.cacheTTL, consumer.config.CacheTTL, "CacheTTL should be preserved in config")
+
+			_ = consumer.Close()
+		})
+	}
+}
+
 // TestMultiTenantConsumer_Stats verifies the Stats() method returns correct statistics.
 func TestMultiTenantConsumer_Stats(t *testing.T) {
 	t.Parallel()

--- a/commons/tenant-manager/core/types.go
+++ b/commons/tenant-manager/core/types.go
@@ -75,8 +75,9 @@ type DatabaseConfig struct {
 // defaults configured on the PostgresManager or MongoManager.
 // If nil (e.g., for older associations without settings), global defaults apply.
 type ConnectionSettings struct {
-	MaxOpenConns int `json:"maxOpenConns"`
-	MaxIdleConns int `json:"maxIdleConns"`
+	MaxOpenConns     int    `json:"maxOpenConns"`
+	MaxIdleConns     int    `json:"maxIdleConns"`
+	StatementTimeout string `json:"statementTimeout,omitempty"`
 }
 
 // TenantConfig represents the tenant configuration from Tenant Manager.

--- a/commons/tenant-manager/postgres/manager.go
+++ b/commons/tenant-manager/postgres/manager.go
@@ -65,6 +65,16 @@ const defaultMaxAllowedOpenConns = 200
 
 const defaultMaxAllowedIdleConns = 50
 
+// validStatementTimeoutPattern matches PostgreSQL-acceptable statement_timeout values:
+// plain integers (interpreted as milliseconds) or integers followed by a unit suffix.
+// Accepted units: us, ms, s, min, h, d.
+var validStatementTimeoutPattern = regexp.MustCompile(`^[0-9]+\s*(us|ms|s|min|h|d)?$`)
+
+// validStatementTimeout checks whether the value is a valid PostgreSQL statement_timeout.
+func validStatementTimeout(v string) bool {
+	return validStatementTimeoutPattern.MatchString(v)
+}
+
 // defaultIdleTimeout is the default duration before a tenant connection becomes
 // eligible for eviction. Connections accessed within this window are considered
 // active and will not be evicted, allowing the pool to grow beyond maxConnections.
@@ -1157,7 +1167,9 @@ func (p *Manager) ApplyConnectionSettings(tenantID string, config *core.TenantCo
 
 	// Apply statementTimeout via SQL when it changed and is non-empty
 	if newSettings.statementTimeout != "" && (!hasPrev || newSettings.statementTimeout != prev.statementTimeout) {
-		if _, err := db.ExecContext(context.Background(), "SET statement_timeout = '"+newSettings.statementTimeout+"'"); err != nil {
+		if !validStatementTimeout(newSettings.statementTimeout) {
+			compatLogger.Warnf("invalid statement_timeout value %q for tenant %s, skipping", newSettings.statementTimeout, tenantID)
+		} else if _, err := db.ExecContext(context.Background(), "SET statement_timeout = '"+newSettings.statementTimeout+"'"); err != nil {
 			compatLogger.Warnf("failed to set statement_timeout for tenant %s: %v", tenantID, err)
 		}
 	}

--- a/commons/tenant-manager/postgres/manager.go
+++ b/commons/tenant-manager/postgres/manager.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -96,8 +97,9 @@ type Manager struct {
 	idleTimeout         time.Duration        // how long before a connection is eligible for eviction
 	lastAccessed        map[string]time.Time // LRU tracking per tenant
 
-	lastSettingsCheck     map[string]time.Time // tracks per-tenant last settings revalidation time
-	settingsCheckInterval time.Duration        // configurable interval between settings revalidation checks
+	lastSettingsCheck     map[string]time.Time          // tracks per-tenant last settings revalidation time
+	settingsCheckInterval time.Duration                 // configurable interval between settings revalidation checks
+	lastAppliedSettings   map[string]appliedSettings    // tracks previously applied pool settings per tenant for change detection
 
 	// revalidateWG tracks in-flight revalidatePoolSettings goroutines so Close()
 	// can wait for them to finish before returning. Without this, goroutines
@@ -105,6 +107,14 @@ type Manager struct {
 	revalidateWG sync.WaitGroup
 
 	defaultConn *PostgresConnection
+}
+
+// appliedSettings tracks the last-applied pool settings for a tenant so that
+// ApplyConnectionSettings can skip redundant writes and only log actual changes.
+type appliedSettings struct {
+	maxOpenConns     int
+	maxIdleConns     int
+	statementTimeout string
 }
 
 type PostgresConnection struct {
@@ -262,6 +272,7 @@ func NewManager(c *client.Client, service string, opts ...Option) *Manager {
 		connections:           make(map[string]*PostgresConnection),
 		lastAccessed:          make(map[string]time.Time),
 		lastSettingsCheck:     make(map[string]time.Time),
+		lastAppliedSettings:   make(map[string]appliedSettings),
 		settingsCheckInterval: defaultSettingsCheckInterval,
 		maxOpenConns:          fallbackMaxOpenConns,
 		maxIdleConns:          fallbackMaxIdleConns,
@@ -957,6 +968,7 @@ func (p *Manager) Close(_ context.Context) error {
 		delete(p.connections, tenantID)
 		delete(p.lastAccessed, tenantID)
 		delete(p.lastSettingsCheck, tenantID)
+		delete(p.lastAppliedSettings, tenantID)
 	}
 
 	p.mu.Unlock()
@@ -987,6 +999,7 @@ func (p *Manager) CloseConnection(_ context.Context, tenantID string) error {
 	delete(p.connections, tenantID)
 	delete(p.lastAccessed, tenantID)
 	delete(p.lastSettingsCheck, tenantID)
+	delete(p.lastAppliedSettings, tenantID)
 
 	return err
 }
@@ -1094,9 +1107,15 @@ func buildConnectionString(cfg *core.PostgreSQLConfig) (string, error) {
 // This is called during the sync loop to revalidate settings that may have changed
 // in the Tenant Manager (e.g., maxOpenConns adjusted from 10 to 30).
 //
+// Settings are only applied when they differ from the previously applied values,
+// avoiding redundant sql.DB calls and noisy logs every sync cycle.
+//
 // Go's sql.DB.SetMaxOpenConns and SetMaxIdleConns are thread-safe and take effect
 // immediately for new connections from the pool. Existing idle connections above the
 // new limit are closed gradually.
+//
+// When statementTimeout is present and has changed, a SET statement_timeout SQL
+// command is executed on the underlying database connection.
 //
 // For MongoDB, the driver does not support changing pool size after client creation,
 // so this method only applies to PostgreSQL connections.
@@ -1106,39 +1125,103 @@ func (p *Manager) ApplyConnectionSettings(tenantID string, config *core.TenantCo
 	conn, ok := p.connections[tenantID]
 	if !ok || conn == nil || conn.ConnectionDB == nil {
 		p.mu.RUnlock()
+
 		return // no cached connection, settings will be applied on next creation
 	}
 
-	connSettings := p.resolveConnectionSettingsFromConfig(config)
-
-	// Determine effective settings: per-tenant if present, otherwise manager defaults.
-	var maxOpen, maxIdle int
-	if connSettings != nil {
-		maxOpen = connSettings.MaxOpenConns
-		maxIdle = connSettings.MaxIdleConns
-	}
-
-	// Fallback to manager defaults for absent/zero values
-	if maxOpen <= 0 {
-		maxOpen = p.maxOpenConns
-	}
-
-	if maxIdle <= 0 {
-		maxIdle = p.maxIdleConns
-	}
-
+	newSettings := p.resolveEffectiveSettings(config)
 	db := *conn.ConnectionDB
+	prev, hasPrev := p.lastAppliedSettings[tenantID]
 
 	p.mu.RUnlock() // Release before thread-safe sql.DB operations
 
 	compatLogger := logcompat.New(p.logger.Base())
-	maxOpen, maxIdle = p.clampPoolSettings(maxOpen, maxIdle, tenantID, compatLogger)
+	newSettings.maxOpenConns, newSettings.maxIdleConns = p.clampPoolSettings(newSettings.maxOpenConns, newSettings.maxIdleConns, tenantID, compatLogger)
 
-	compatLogger.Infof("applying connection settings for tenant %s module %s: maxOpenConns=%d, maxIdleConns=%d",
-		tenantID, p.module, maxOpen, maxIdle)
+	// Skip if nothing changed (after first apply)
+	if hasPrev && newSettings == prev {
+		return
+	}
 
-	db.SetMaxOpenConns(maxOpen)
-	db.SetMaxIdleConns(maxIdle)
+	// Build a targeted log message listing only the fields that changed.
+	p.logSettingsChanges(compatLogger, tenantID, prev, newSettings, hasPrev)
+
+	// Apply pool settings
+	if !hasPrev || newSettings.maxOpenConns != prev.maxOpenConns {
+		db.SetMaxOpenConns(newSettings.maxOpenConns)
+	}
+
+	if !hasPrev || newSettings.maxIdleConns != prev.maxIdleConns {
+		db.SetMaxIdleConns(newSettings.maxIdleConns)
+	}
+
+	// Apply statementTimeout via SQL when it changed and is non-empty
+	if newSettings.statementTimeout != "" && (!hasPrev || newSettings.statementTimeout != prev.statementTimeout) {
+		if _, err := db.ExecContext(context.Background(), "SET statement_timeout = '"+newSettings.statementTimeout+"'"); err != nil {
+			compatLogger.Warnf("failed to set statement_timeout for tenant %s: %v", tenantID, err)
+		}
+	}
+
+	// Store the new settings under lock
+	p.mu.Lock()
+	p.lastAppliedSettings[tenantID] = newSettings
+	p.mu.Unlock()
+}
+
+// resolveEffectiveSettings determines the effective pool settings for a tenant by
+// checking per-tenant config first, then falling back to manager defaults.
+func (p *Manager) resolveEffectiveSettings(config *core.TenantConfig) appliedSettings {
+	connSettings := p.resolveConnectionSettingsFromConfig(config)
+
+	var s appliedSettings
+
+	if connSettings != nil {
+		s.maxOpenConns = connSettings.MaxOpenConns
+		s.maxIdleConns = connSettings.MaxIdleConns
+		s.statementTimeout = connSettings.StatementTimeout
+	}
+
+	// Fallback to manager defaults for absent/zero values
+	if s.maxOpenConns <= 0 {
+		s.maxOpenConns = p.maxOpenConns
+	}
+
+	if s.maxIdleConns <= 0 {
+		s.maxIdleConns = p.maxIdleConns
+	}
+
+	return s
+}
+
+// logSettingsChanges logs a summary of which connection settings changed for a tenant.
+// When hasPrev is false (first apply), all values are logged. When hasPrev is true,
+// only fields that differ from the previous settings are included.
+func (p *Manager) logSettingsChanges(logger *logcompat.Logger, tenantID string, prev, curr appliedSettings, hasPrev bool) {
+	if !hasPrev {
+		logger.Infof("applying connection settings for tenant %s module %s: maxOpenConns=%d, maxIdleConns=%d, statementTimeout=%s",
+			tenantID, p.module, curr.maxOpenConns, curr.maxIdleConns, curr.statementTimeout)
+
+		return
+	}
+
+	var changes []string
+
+	if curr.maxOpenConns != prev.maxOpenConns {
+		changes = append(changes, fmt.Sprintf("maxOpenConns %d->%d", prev.maxOpenConns, curr.maxOpenConns))
+	}
+
+	if curr.maxIdleConns != prev.maxIdleConns {
+		changes = append(changes, fmt.Sprintf("maxIdleConns %d->%d", prev.maxIdleConns, curr.maxIdleConns))
+	}
+
+	if curr.statementTimeout != prev.statementTimeout {
+		changes = append(changes, fmt.Sprintf("statementTimeout %s->%s", prev.statementTimeout, curr.statementTimeout))
+	}
+
+	if len(changes) > 0 {
+		logger.Infof("connection settings changed for tenant %s module %s: %s",
+			tenantID, p.module, strings.Join(changes, ", "))
+	}
 }
 
 // WithConnectionLimits sets the default per-tenant connection limits.

--- a/commons/tenant-manager/postgres/manager_test.go
+++ b/commons/tenant-manager/postgres/manager_test.go
@@ -1905,6 +1905,78 @@ func TestManager_ApplyConnectionSettings_StatementTimeout(t *testing.T) {
 		"should log the statementTimeout change")
 }
 
+func TestValidStatementTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		valid bool
+	}{
+		{name: "plain_integer_milliseconds", value: "30000", valid: true},
+		{name: "zero", value: "0", valid: true},
+		{name: "with_ms_suffix", value: "500ms", valid: true},
+		{name: "with_s_suffix", value: "30s", valid: true},
+		{name: "with_min_suffix", value: "2min", valid: true},
+		{name: "with_h_suffix", value: "1h", valid: true},
+		{name: "with_d_suffix", value: "7d", valid: true},
+		{name: "with_us_suffix", value: "100us", valid: true},
+		{name: "sql_injection_attempt", value: "'; DROP TABLE users; --", valid: false},
+		{name: "negative_value", value: "-1", valid: false},
+		{name: "empty_string", value: "", valid: false},
+		{name: "letters_only", value: "abc", valid: false},
+		{name: "invalid_unit", value: "30x", valid: false},
+		{name: "special_chars", value: "30; DROP", valid: false},
+		{name: "quoted_value", value: "'30s'", valid: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.valid, validStatementTimeout(tt.value),
+				"validStatementTimeout(%q) = %v, want %v", tt.value, !tt.valid, tt.valid)
+		})
+	}
+}
+
+func TestManager_ApplyConnectionSettings_RejectsInvalidStatementTimeout(t *testing.T) {
+	t.Parallel()
+
+	c := mustNewTestClient(t, "http://localhost:8080")
+	capLogger := testutil.NewCapturingLogger()
+	manager := NewManager(c, "ledger",
+		WithModule("onboarding"),
+		WithLogger(capLogger),
+	)
+
+	tDB := &trackingDB{}
+	var db dbresolver.DB = tDB
+
+	manager.connections["tenant-123"] = &PostgresConnection{
+		ConnectionDB: &db,
+	}
+
+	config := &core.TenantConfig{
+		Databases: map[string]core.DatabaseConfig{
+			"onboarding": {
+				ConnectionSettings: &core.ConnectionSettings{
+					MaxOpenConns:     30,
+					MaxIdleConns:     10,
+					StatementTimeout: "'; DROP TABLE users; --",
+				},
+			},
+		},
+	}
+
+	manager.ApplyConnectionSettings("tenant-123", config)
+
+	queries := tDB.ExecQueries()
+	assert.Empty(t, queries, "should NOT execute SET with invalid statement_timeout value")
+	assert.True(t, capLogger.ContainsSubstring("invalid statement_timeout"),
+		"should log warning about invalid statement_timeout value")
+}
+
 func TestManager_CloseConnection_CleansUpLastAppliedSettings(t *testing.T) {
 	t.Parallel()
 

--- a/commons/tenant-manager/postgres/manager_test.go
+++ b/commons/tenant-manager/postgres/manager_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -72,19 +74,42 @@ func (m *pingableDB) PrimaryDBs() []*sql.DB              { return nil }
 func (m *pingableDB) ReplicaDBs() []*sql.DB              { return nil }
 func (m *pingableDB) Stats() sql.DBStats                 { return sql.DBStats{} }
 
-// trackingDB extends pingableDB to track SetMaxOpenConns/SetMaxIdleConns calls.
+// trackingDB extends pingableDB to track SetMaxOpenConns/SetMaxIdleConns calls
+// and ExecContext queries (e.g., SET statement_timeout).
 // Fields use int32 with atomic operations to avoid data races when written
 // by async goroutines (revalidatePoolSettings) and read by test assertions.
 type trackingDB struct {
 	pingableDB
 	maxOpenConns int32
 	maxIdleConns int32
+	mu           sync.Mutex
+	execQueries  []string
 }
 
 func (t *trackingDB) SetMaxOpenConns(n int) { atomic.StoreInt32(&t.maxOpenConns, int32(n)) }
 func (t *trackingDB) SetMaxIdleConns(n int) { atomic.StoreInt32(&t.maxIdleConns, int32(n)) }
 func (t *trackingDB) MaxOpenConns() int32   { return atomic.LoadInt32(&t.maxOpenConns) }
 func (t *trackingDB) MaxIdleConns() int32   { return atomic.LoadInt32(&t.maxIdleConns) }
+
+func (t *trackingDB) ExecContext(_ context.Context, query string, _ ...interface{}) (sql.Result, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.execQueries = append(t.execQueries, query)
+
+	return nil, nil
+}
+
+// ExecQueries returns a thread-safe copy of all executed queries.
+func (t *trackingDB) ExecQueries() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	copied := make([]string, len(t.execQueries))
+	copy(copied, t.execQueries)
+
+	return copied
+}
 
 func TestNewManager(t *testing.T) {
 	t.Run("creates manager with client and service", func(t *testing.T) {
@@ -1295,6 +1320,7 @@ func TestManager_Close_CleansUpLastSettingsCheck(t *testing.T) {
 		}
 		manager.lastAccessed[id] = time.Now()
 		manager.lastSettingsCheck[id] = time.Now()
+		manager.lastAppliedSettings[id] = appliedSettings{maxOpenConns: 25, maxIdleConns: 5}
 	}
 
 	err := manager.Close(context.Background())
@@ -1304,6 +1330,7 @@ func TestManager_Close_CleansUpLastSettingsCheck(t *testing.T) {
 	assert.Empty(t, manager.connections, "all connections should be removed after Close")
 	assert.Empty(t, manager.lastAccessed, "all lastAccessed should be removed after Close")
 	assert.Empty(t, manager.lastSettingsCheck, "all lastSettingsCheck should be removed after Close")
+	assert.Empty(t, manager.lastAppliedSettings, "all lastAppliedSettings should be removed after Close")
 }
 
 func TestManager_ApplyConnectionSettings_LogsValues(t *testing.T) {
@@ -1341,7 +1368,7 @@ func TestManager_ApplyConnectionSettings_LogsValues(t *testing.T) {
 	assert.Equal(t, int32(30), tDB.MaxOpenConns())
 	assert.Equal(t, int32(10), tDB.MaxIdleConns())
 	assert.True(t, capLogger.ContainsSubstring("applying connection settings"),
-		"ApplyConnectionSettings should log when applying values")
+		"ApplyConnectionSettings should log on first apply")
 }
 
 func TestManager_GetConnection_DisabledRevalidation_WithZero(t *testing.T) {
@@ -1620,6 +1647,284 @@ func TestManager_ApplyConnectionSettings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestManager_ApplyConnectionSettings_ChangeDetection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		preApplySettings    *appliedSettings // nil = no previous settings (first apply)
+		config              *core.TenantConfig
+		expectSetMaxOpen    bool
+		expectSetMaxIdle    bool
+		expectLog           bool
+		expectLogSubstring  string
+		noLogSubstring      string
+		expectExecQuery     string // expected SET statement_timeout query
+		expectNoExecQueries bool
+	}{
+		{
+			name:             "first_apply_logs_and_applies_all",
+			preApplySettings: nil,
+			config: &core.TenantConfig{
+				Databases: map[string]core.DatabaseConfig{
+					"onboarding": {
+						ConnectionSettings: &core.ConnectionSettings{
+							MaxOpenConns:     30,
+							MaxIdleConns:     10,
+							StatementTimeout: "5s",
+						},
+					},
+				},
+			},
+			expectSetMaxOpen:   true,
+			expectSetMaxIdle:   true,
+			expectLog:          true,
+			expectLogSubstring: "applying connection settings",
+			expectExecQuery:    "SET statement_timeout = '5s'",
+		},
+		{
+			name: "no_change_skips_apply_and_log",
+			preApplySettings: &appliedSettings{
+				maxOpenConns:     30,
+				maxIdleConns:     10,
+				statementTimeout: "5s",
+			},
+			config: &core.TenantConfig{
+				Databases: map[string]core.DatabaseConfig{
+					"onboarding": {
+						ConnectionSettings: &core.ConnectionSettings{
+							MaxOpenConns:     30,
+							MaxIdleConns:     10,
+							StatementTimeout: "5s",
+						},
+					},
+				},
+			},
+			expectSetMaxOpen:    false,
+			expectSetMaxIdle:    false,
+			expectLog:           false,
+			expectNoExecQueries: true,
+		},
+		{
+			name: "maxOpenConns_change_logs_delta",
+			preApplySettings: &appliedSettings{
+				maxOpenConns:     30,
+				maxIdleConns:     10,
+				statementTimeout: "5s",
+			},
+			config: &core.TenantConfig{
+				Databases: map[string]core.DatabaseConfig{
+					"onboarding": {
+						ConnectionSettings: &core.ConnectionSettings{
+							MaxOpenConns:     50,
+							MaxIdleConns:     10,
+							StatementTimeout: "5s",
+						},
+					},
+				},
+			},
+			expectSetMaxOpen:    true,
+			expectSetMaxIdle:    false,
+			expectLog:           true,
+			expectLogSubstring:  "maxOpenConns 30->50",
+			noLogSubstring:      "maxIdleConns",
+			expectNoExecQueries: true,
+		},
+		{
+			name: "statementTimeout_change_executes_SET",
+			preApplySettings: &appliedSettings{
+				maxOpenConns:     30,
+				maxIdleConns:     10,
+				statementTimeout: "5s",
+			},
+			config: &core.TenantConfig{
+				Databases: map[string]core.DatabaseConfig{
+					"onboarding": {
+						ConnectionSettings: &core.ConnectionSettings{
+							MaxOpenConns:     30,
+							MaxIdleConns:     10,
+							StatementTimeout: "10s",
+						},
+					},
+				},
+			},
+			expectSetMaxOpen:   false,
+			expectSetMaxIdle:   false,
+			expectLog:          true,
+			expectLogSubstring: "statementTimeout 5s->10s",
+			expectExecQuery:    "SET statement_timeout = '10s'",
+		},
+		{
+			name: "statementTimeout_empty_skips_exec",
+			preApplySettings: &appliedSettings{
+				maxOpenConns:     30,
+				maxIdleConns:     10,
+				statementTimeout: "",
+			},
+			config: &core.TenantConfig{
+				Databases: map[string]core.DatabaseConfig{
+					"onboarding": {
+						ConnectionSettings: &core.ConnectionSettings{
+							MaxOpenConns: 50,
+							MaxIdleConns: 10,
+						},
+					},
+				},
+			},
+			expectSetMaxOpen:    true,
+			expectSetMaxIdle:    false,
+			expectLog:           true,
+			expectNoExecQueries: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := mustNewTestClient(t, "http://localhost:8080")
+			capLogger := testutil.NewCapturingLogger()
+			manager := NewManager(c, "ledger",
+				WithModule("onboarding"),
+				WithLogger(capLogger),
+			)
+
+			tDB := &trackingDB{}
+			var db dbresolver.DB = tDB
+
+			manager.connections["tenant-123"] = &PostgresConnection{
+				ConnectionDB: &db,
+			}
+
+			if tt.preApplySettings != nil {
+				manager.lastAppliedSettings["tenant-123"] = *tt.preApplySettings
+			}
+
+			manager.ApplyConnectionSettings("tenant-123", tt.config)
+
+			if tt.expectSetMaxOpen {
+				assert.NotEqual(t, int32(0), tDB.MaxOpenConns(),
+					"maxOpenConns should have been set")
+			}
+
+			if tt.expectSetMaxIdle {
+				assert.NotEqual(t, int32(0), tDB.MaxIdleConns(),
+					"maxIdleConns should have been set")
+			}
+
+			if tt.expectLog {
+				assert.True(t, capLogger.ContainsSubstring(tt.expectLogSubstring),
+					"expected log message containing %q, got: %v", tt.expectLogSubstring, capLogger.GetMessages())
+			} else {
+				// When no log is expected, verify the capturing logger got nothing
+				// (other than potential clamping warnings which we don't trigger here)
+				for _, msg := range capLogger.GetMessages() {
+					assert.False(t, strings.Contains(msg, "applying connection settings") || strings.Contains(msg, "connection settings changed"),
+						"unexpected log message: %s", msg)
+				}
+			}
+
+			if tt.noLogSubstring != "" {
+				assert.False(t, capLogger.ContainsSubstring(tt.noLogSubstring),
+					"log should NOT contain %q, got: %v", tt.noLogSubstring, capLogger.GetMessages())
+			}
+
+			queries := tDB.ExecQueries()
+			if tt.expectNoExecQueries {
+				assert.Empty(t, queries, "no ExecContext queries expected")
+			}
+
+			if tt.expectExecQuery != "" {
+				assert.Contains(t, queries, tt.expectExecQuery,
+					"expected ExecContext query %q", tt.expectExecQuery)
+			}
+		})
+	}
+}
+
+func TestManager_ApplyConnectionSettings_StatementTimeout(t *testing.T) {
+	t.Parallel()
+
+	c := mustNewTestClient(t, "http://localhost:8080")
+	capLogger := testutil.NewCapturingLogger()
+	manager := NewManager(c, "ledger",
+		WithModule("onboarding"),
+		WithLogger(capLogger),
+	)
+
+	tDB := &trackingDB{}
+	var db dbresolver.DB = tDB
+
+	manager.connections["tenant-123"] = &PostgresConnection{
+		ConnectionDB: &db,
+	}
+
+	// First apply with statementTimeout
+	config := &core.TenantConfig{
+		Databases: map[string]core.DatabaseConfig{
+			"onboarding": {
+				ConnectionSettings: &core.ConnectionSettings{
+					MaxOpenConns:     30,
+					MaxIdleConns:     10,
+					StatementTimeout: "5s",
+				},
+			},
+		},
+	}
+
+	manager.ApplyConnectionSettings("tenant-123", config)
+
+	queries := tDB.ExecQueries()
+	require.Len(t, queries, 1, "should execute SET statement_timeout on first apply")
+	assert.Equal(t, "SET statement_timeout = '5s'", queries[0])
+
+	// Second apply with same settings — no ExecContext
+	capLogger.Clear()
+	manager.ApplyConnectionSettings("tenant-123", config)
+
+	assert.Len(t, tDB.ExecQueries(), 1, "should NOT execute SET again when statementTimeout unchanged")
+
+	// Third apply with changed statementTimeout
+	config.Databases["onboarding"] = core.DatabaseConfig{
+		ConnectionSettings: &core.ConnectionSettings{
+			MaxOpenConns:     30,
+			MaxIdleConns:     10,
+			StatementTimeout: "15s",
+		},
+	}
+
+	manager.ApplyConnectionSettings("tenant-123", config)
+
+	queries = tDB.ExecQueries()
+	require.Len(t, queries, 2, "should execute SET again when statementTimeout changed")
+	assert.Equal(t, "SET statement_timeout = '15s'", queries[1])
+	assert.True(t, capLogger.ContainsSubstring("statementTimeout 5s->15s"),
+		"should log the statementTimeout change")
+}
+
+func TestManager_CloseConnection_CleansUpLastAppliedSettings(t *testing.T) {
+	t.Parallel()
+
+	c := mustNewTestClient(t, "http://localhost:8080")
+	manager := NewManager(c, "ledger",
+		WithLogger(testutil.NewMockLogger()),
+	)
+
+	db := &pingableDB{}
+	var dbIface dbresolver.DB = db
+
+	manager.connections["tenant-123"] = &PostgresConnection{
+		ConnectionDB: &dbIface,
+	}
+	manager.lastAppliedSettings["tenant-123"] = appliedSettings{maxOpenConns: 25, maxIdleConns: 5}
+
+	err := manager.CloseConnection(context.Background(), "tenant-123")
+	require.NoError(t, err)
+
+	assert.Empty(t, manager.lastAppliedSettings, "lastAppliedSettings should be cleaned up after CloseConnection")
 }
 
 func TestManager_Stats_ActiveConnections(t *testing.T) {


### PR DESCRIPTION
## Summary

- **CacheTTL propagation**: `MultiTenantConfig.CacheTTL` is now passed to the consumer's internal HTTP client. Previously the consumer always used the 1-hour default, ignoring the service's `MULTI_TENANT_CACHE_TTL_SEC`.
- **StatementTimeout**: Added `StatementTimeout string` to `core.ConnectionSettings`. Applied via `SET statement_timeout` on the PG pool when changed.
- **Change detection**: `ApplyConnectionSettings` now tracks previous values per tenant. Only applies and logs fields that actually changed. No-op when nothing changed.

## Files changed

| File | Change |
|------|--------|
| `consumer/multi_tenant.go` | `CacheTTL` field + propagation to client |
| `core/types.go` | `StatementTimeout` field on `ConnectionSettings` |
| `postgres/manager.go` | `appliedSettings` tracking, smart `ApplyConnectionSettings`, `statementTimeout` via SQL SET |
| `postgres/manager_test.go` | Tests for change detection, statementTimeout, cleanup |
| `consumer/multi_tenant_test.go` | Tests for CacheTTL propagation |

## Behavior

```
Revalidation cycle (30s):
  ├─ Fetch config (cache hit or API call based on CacheTTL)
  ├─ Compare maxOpenConns, maxIdleConns, statementTimeout vs previous
  ├─ Changed → apply + log "connection settings changed for tenant X: maxOpen 7→13"
  └─ No change → no-op (no log, no DB calls)
```

## Test plan

- [ ] `go test ./commons/tenant-manager/... -count=1 -race` passes
- [ ] Change maxOpenConns in tenant-manager → log shows `maxOpenConns X→Y` within CacheTTL
- [ ] Change statementTimeout → log shows `statementTimeout →30s` + SQL SET executed
- [ ] No change → no log output from ApplyConnectionSettings

🤖 Generated with [Claude Code](https://claude.com/claude-code)