### PR TITLE
feat: event-driven tenant discovery in MultiTenantConsumer

### DIFF
--- a/commons/tenant-manager/consumer/multi_tenant.go
+++ b/commons/tenant-manager/consumer/multi_tenant.go
@@ -340,17 +340,25 @@ func (c *MultiTenantConsumer) Run(ctx context.Context) error {
 // It also closes the pmClient to prevent goroutine leaks from its
 // InMemoryCache cleanup loop.
 func (c *MultiTenantConsumer) Close() error {
+	// Snapshot the event listener reference and mark closed under the lock,
+	// then release BEFORE calling Stop(). Stop() waits for the listener
+	// goroutine to finish, and that goroutine may be executing an event
+	// handler that acquires c.mu — holding the lock here would deadlock.
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	c.closed = true
+	listener := c.eventListener
+	c.mu.Unlock()
 
-	// Stop event listener if running.
-	if c.eventListener != nil {
-		if err := c.eventListener.Stop(); err != nil {
+	// Stop event listener outside the lock to avoid deadlock.
+	if listener != nil {
+		if err := listener.Stop(); err != nil {
 			c.logger.Warnf("failed to stop event listener: %v", err)
 		}
 	}
+
+	// Re-acquire lock for the rest of the cleanup.
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	// Cancel all tenant contexts
 	for tenantID, cancel := range c.tenants {


### PR DESCRIPTION
## Summary

- Replace polling-based tenant discovery with Redis Pub/Sub + lazy-load
- Consumer pods boot with empty tenant map, subscribe to `tenant-events:*`, lazy-load on first request
- All state changes arrive via Redis Pub/Sub events — polling eliminated entirely
- 12 event types handled (tenant lifecycle + service association + credentials + connections)

## Changes

### New package: `commons/tenant-manager/event/`
- `TenantLifecycleEvent` envelope, 12 event type constants, 7 typed payload structs
- `TenantEventListener` — Redis Pub/Sub subscriber with graceful shutdown
- `ParseEvent()`, `ChannelForTenant()` helpers
- Payloads aligned with publisher contract (tenant-manager #222)

### New components in `consumer/`
- **TTL cache** (`multi_tenant_cache.go`) — 12h default, lazy eviction, thread-safe
- **Lazy-load** (`multi_tenant_lazy.go`) — on-demand tenant fetch with per-tenant mutex
- **Event dispatch** (`multi_tenant_events.go` + `_handlers.go`) — 12 handlers with service filtering, jitter, full TenantConfig population

### Breaking changes
- `NewMultiTenantConsumerWithError()` now requires `redisClient` parameter
- `WithRedisClient()` option removed (now constructor param)
- Deleted all polling code: `syncActiveTenants()`, `discoverTenants()`, etc.
- Deleted `multi_tenant_sync.go`, `multi_tenant_revalidate.go`

### Fixes (from review feedback)
- Aligned JSON payload structs with publisher contract (`modules` as `[]string`, `secret_paths` as nested map, `messaging_config` with flat `rabbitmq_secret_path`)
- `handleServiceAssociated` / `handleServiceReactivated` now populate full `TenantConfig` (ConnectionSettings, Databases, Messaging)
- `Close()` stops event listener outside `c.mu` lock to prevent deadlock

## Test plan

- [x] All 15 tenant-manager packages pass with `-race`
- [x] ~60+ new test cases covering event types, listener, cache, lazy-load, dispatch, Run/Close
- [x] Lint: 0 issues
- [x] No `panic()` in production code
- [ ] Integration test with real Redis Pub/Sub (future PR)

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)