### PR TITLE
fix(event): use #nosec annotation for gosec G101 false positive

### DIFF
--- a/commons/tenant-manager/event/types.go
+++ b/commons/tenant-manager/event/types.go
@@ -32,7 +32,7 @@ const (
 	EventTenantServiceReactivated   = "tenant.service.reactivated"
 
 	// Credential and connection events.
-	EventTenantCredentialsRotated = "tenant.credentials.rotated" //nolint:gosec // Not a credential, event type constant
+	EventTenantCredentialsRotated = "tenant.credentials.rotated" //#nosec G101 -- event type constant, not a credential
 	EventTenantConnectionsUpdated = "tenant.connections.updated"
 )
 


### PR DESCRIPTION
## Summary

- Fix gosec G101 false positive on `EventTenantCredentialsRotated` constant
- Replace `//nolint:gosec` (golangci-lint syntax) with `#nosec G101` (standalone gosec syntax)

The CI runs gosec standalone, which does not recognize `//nolint:gosec` directives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)