### PR TITLE
fix(consumer): eagerly reload credentials on tenant.credentials.rotated

### DIFF
--- a/commons/tenant-manager/consumer/multi_tenant_events_handlers.go
+++ b/commons/tenant-manager/consumer/multi_tenant_events_handlers.go
@@ -276,24 +276,33 @@ func (c *MultiTenantConsumer) handleServiceReactivated(
 	return nil
 }
 
-// handleCredentialsRotated closes existing pools, applies jitter, and deletes
-// the tenant from cache to force a lazy-reload with new credentials on the next request.
+// handleCredentialsRotated closes existing pools, applies jitter, and eagerly
+// reloads tenant config via /connections to reconnect with new credentials.
+// Unlike other events that rely on lazy-load, credential rotation requires
+// immediate reconnection to avoid failed queries between the event and the
+// next inbound request.
 func (c *MultiTenantConsumer) handleCredentialsRotated(
 	ctx context.Context,
 	evt event.TenantLifecycleEvent,
 	logger *logcompat.Logger,
 ) error {
-	logger.InfofCtx(ctx, "tenant.credentials.rotated: closing pools for tenant=%s with jitter", evt.TenantID)
+	logger.InfofCtx(ctx, "tenant.credentials.rotated: closing pools for tenant=%s", evt.TenantID)
 
-	// Close existing pools
+	// Close existing pools and remove from cache
 	c.closeTenantConnections(ctx, evt.TenantID, logger)
 
-	// Apply jitter to prevent thundering herd
+	// Apply jitter to prevent thundering herd when multiple pods react simultaneously
 	c.applyJitter(ctx)
 
-	// Cache was already deleted by closeTenantConnections.
-	// Next request will trigger lazy-reload with new credentials.
-	logger.InfofCtx(ctx, "tenant.credentials.rotated: tenant=%s ready for lazy-reload", evt.TenantID)
+	// Eagerly reload tenant config from tenant-manager /connections endpoint.
+	// This fetches new credentials from Secrets Manager and rebuilds pools
+	// immediately, avoiding a window of failed queries.
+	if err := c.loadTenant(ctx, evt.TenantID); err != nil {
+		logger.WarnfCtx(ctx, "tenant.credentials.rotated: eager reload failed for tenant=%s (will retry on next request): %v", evt.TenantID, err)
+		return nil // non-fatal: next request will trigger lazy-load as fallback
+	}
+
+	logger.InfofCtx(ctx, "tenant.credentials.rotated: tenant=%s reconnected with new credentials", evt.TenantID)
 
 	return nil
 }

--- a/commons/tenant-manager/consumer/multi_tenant_events_test.go
+++ b/commons/tenant-manager/consumer/multi_tenant_events_test.go
@@ -7,6 +7,9 @@ package consumer
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -535,27 +538,122 @@ func TestHandleLifecycleEvent_ServiceEvent_FiltersMismatchedService(t *testing.T
 func TestHandleLifecycleEvent_CredentialsRotated(t *testing.T) {
 	t.Parallel()
 
-	consumer := newEventsTestConsumer(t)
-	seedCacheTenant(consumer, "tenant-cred-001")
-	ctx := context.Background()
+	t.Run("eager_reload_succeeds", func(t *testing.T) {
+		t.Parallel()
 
-	payload := event.CredentialsRotatedPayload{
-		ServiceName:    testServiceName,
-		CredentialType: "database",
-		NewSecretPath:  "/secrets/new-path",
-	}
+		// Set up an API server that returns a valid TenantConfig on the /connections endpoint.
+		newConfig := &core.TenantConfig{
+			ID:         "tenant-cred-001",
+			TenantSlug: "acme-rotated",
+			Service:    testServiceName,
+			Status:     "active",
+		}
 
-	evt := event.TenantLifecycleEvent{
-		EventID:   "evt-cred",
-		EventType: event.EventTenantCredentialsRotated,
-		TenantID:  "tenant-cred-001",
-		Payload:   mustMarshalPayload(t, payload),
-	}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 
-	err := consumer.handleLifecycleEvent(ctx, evt)
-	require.NoError(t, err, "tenant.credentials.rotated should not return error")
+			// The /connections endpoint is used by GetTenantConfig (loadTenant)
+			if strings.Contains(r.URL.Path, "/connections") {
+				if err := json.NewEncoder(w).Encode(newConfig); err != nil {
+					t.Errorf("failed to encode tenant config response: %v", err)
+				}
 
-	// Verify tenant removed from cache (forces lazy-reload with new credentials)
-	_, ok := consumer.cache.Get("tenant-cred-001")
-	assert.False(t, ok, "tenant.credentials.rotated should remove tenant from cache for lazy-reload")
+				return
+			}
+
+			// Default: return empty tenant list for other endpoints (e.g. tenant sync)
+			if err := json.NewEncoder(w).Encode([]*core.TenantConfig{}); err != nil {
+				t.Errorf("failed to encode empty response: %v", err)
+			}
+		}))
+		t.Cleanup(server.Close)
+
+		consumer := mustNewConsumer(t, dummyRabbitMQManager(), newTestConfig(server.URL), testutil.NewMockLogger())
+		consumer.mu.Lock()
+		consumer.parentCtx = context.Background()
+		consumer.mu.Unlock()
+		t.Cleanup(func() { consumer.Close() })
+
+		seedCacheTenant(consumer, "tenant-cred-001")
+		ctx := context.Background()
+
+		payload := event.CredentialsRotatedPayload{
+			ServiceName:    testServiceName,
+			CredentialType: "database",
+			NewSecretPath:  "/secrets/new-path",
+		}
+
+		evt := event.TenantLifecycleEvent{
+			EventID:   "evt-cred",
+			EventType: event.EventTenantCredentialsRotated,
+			TenantID:  "tenant-cred-001",
+			Payload:   mustMarshalPayload(t, payload),
+		}
+
+		err := consumer.handleLifecycleEvent(ctx, evt)
+		require.NoError(t, err, "tenant.credentials.rotated should not return error")
+
+		// Verify tenant is back in cache (eager reload via loadTenant fetched new credentials)
+		entry, ok := consumer.cache.Get("tenant-cred-001")
+		assert.True(t, ok, "tenant.credentials.rotated should eagerly reload tenant into cache")
+		require.NotNil(t, entry, "cache entry should not be nil after eager reload")
+		assert.Equal(t, "acme-rotated", entry.config.TenantSlug, "cache should contain the reloaded config")
+
+		// Verify tenant marked as known
+		consumer.mu.RLock()
+		known := consumer.knownTenants["tenant-cred-001"]
+		consumer.mu.RUnlock()
+		assert.True(t, known, "tenant.credentials.rotated should mark tenant as known after reload")
+	})
+
+	t.Run("eager_reload_fails_gracefully", func(t *testing.T) {
+		t.Parallel()
+
+		// Set up an API server that returns 500 on the /connections endpoint,
+		// simulating a temporary failure. The handler should still return nil.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			if strings.Contains(r.URL.Path, "/connections") {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"error":"temporary failure"}`))
+
+				return
+			}
+
+			if err := json.NewEncoder(w).Encode([]*core.TenantConfig{}); err != nil {
+				t.Errorf("failed to encode empty response: %v", err)
+			}
+		}))
+		t.Cleanup(server.Close)
+
+		consumer := mustNewConsumer(t, dummyRabbitMQManager(), newTestConfig(server.URL), testutil.NewMockLogger())
+		consumer.mu.Lock()
+		consumer.parentCtx = context.Background()
+		consumer.mu.Unlock()
+		t.Cleanup(func() { consumer.Close() })
+
+		seedCacheTenant(consumer, "tenant-cred-002")
+		ctx := context.Background()
+
+		payload := event.CredentialsRotatedPayload{
+			ServiceName:    testServiceName,
+			CredentialType: "database",
+			NewSecretPath:  "/secrets/new-path",
+		}
+
+		evt := event.TenantLifecycleEvent{
+			EventID:   "evt-cred-fail",
+			EventType: event.EventTenantCredentialsRotated,
+			TenantID:  "tenant-cred-002",
+			Payload:   mustMarshalPayload(t, payload),
+		}
+
+		err := consumer.handleLifecycleEvent(ctx, evt)
+		require.NoError(t, err, "tenant.credentials.rotated should return nil even when eager reload fails")
+
+		// Verify tenant is NOT in cache (eager reload failed, fallback to lazy-load on next request)
+		_, ok := consumer.cache.Get("tenant-cred-002")
+		assert.False(t, ok, "tenant should not be in cache when eager reload fails (lazy-load fallback)")
+	})
 }


### PR DESCRIPTION
## Summary

- `handleCredentialsRotated` now calls `loadTenant()` immediately after closing pools + jitter, instead of waiting for the next request to trigger lazy-load
- This fetches new credentials from tenant-manager `/connections` endpoint and rebuilds pools in place
- Avoids a window of failed queries between the credential rotation event and the next inbound request
- If eager reload fails, falls back gracefully to lazy-load on next request (non-fatal)

## Why

Credential rotation means the old pool **will fail** on the next query. Waiting for a request to trigger lazy-load creates a window where queries fail unnecessarily. For low-traffic tenants, this window could be minutes.

Other events (like `tenant.service.reactivated`) are fine with lazy-load because there's no urgency — the service just came back, the next request will set things up.

## Test plan

- [x] `TestHandleLifecycleEvent_CredentialsRotated/eager_reload_succeeds` — verifies tenant is back in cache with reloaded config
- [x] `TestHandleLifecycleEvent_CredentialsRotated/eager_reload_fails_gracefully` — verifies handler returns nil when `/connections` fails (fallback to lazy-load)
- [x] All existing consumer tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)