### PR TITLE
feat(tenant-manager): add NewTenantPubSubRedisClient helper with TLS support

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -418,6 +418,13 @@ SYSTEMPLANE_MONGODB_POLL_INTERVAL_SEC=5
 # Default: (none — polling mode)
 # MULTI_TENANT_REDIS_URL=
 
+# Enable TLS for the multi-tenant Pub/Sub Redis connection.
+# Required when connecting to Redis/Valkey instances that enforce TLS (e.g., AWS ElastiCache).
+# Independent from the service's own Redis TLS configuration.
+# Type: bool
+# Default: false
+# MULTI_TENANT_REDIS_TLS=false
+
 # Tenant cache TTL for event-driven mode.
 # Each cached tenant entry expires after this duration.  On expiry, the next
 # request triggers a fresh lazy-load from tenant-manager.

--- a/commons/tenant-manager/redis/client.go
+++ b/commons/tenant-manager/redis/client.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package redis
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const defaultPort = "6379"
+
+type TenantPubSubRedisConfig struct {
+	Host     string
+	Port     string
+	Password string
+	TLS      bool
+}
+
+// BuildOptions translates the high-level configuration into go-redis Options.
+// It validates required fields and applies sensible defaults (port 6379,
+// TLS 1.2 minimum version).
+func BuildOptions(cfg TenantPubSubRedisConfig) (*redis.Options, error) {
+	if cfg.Host == "" {
+		return nil, errors.New("tenant pubsub redis: host is required")
+	}
+
+	port := cfg.Port
+	if port == "" {
+		port = defaultPort
+	}
+
+	opts := &redis.Options{
+		Addr: net.JoinHostPort(cfg.Host, port),
+	}
+
+	if cfg.Password != "" {
+		opts.Password = cfg.Password
+	}
+
+	if cfg.TLS {
+		opts.TLSConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+	}
+
+	return opts, nil
+}
+
+// NewTenantPubSubRedisClient creates a go-redis client configured for tenant
+// event Pub/Sub.  It dials Redis immediately to verify connectivity.
+func NewTenantPubSubRedisClient(ctx context.Context, cfg TenantPubSubRedisConfig) (redis.UniversalClient, error) {
+	opts, err := BuildOptions(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	client := redis.NewClient(opts)
+
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("tenant pubsub redis: ping failed: %w", err)
+	}
+
+	return client, nil
+}

--- a/commons/tenant-manager/redis/client_test.go
+++ b/commons/tenant-manager/redis/client_test.go
@@ -1,0 +1,121 @@
+package redis
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildOptions_DefaultPort(t *testing.T) {
+	t.Parallel()
+
+	cfg := TenantPubSubRedisConfig{
+		Host: "localhost",
+	}
+
+	opts, err := BuildOptions(cfg)
+
+	require.NoError(t, err)
+	assert.Equal(t, "localhost:6379", opts.Addr)
+}
+
+func TestBuildOptions_CustomPort(t *testing.T) {
+	t.Parallel()
+
+	cfg := TenantPubSubRedisConfig{
+		Host: "redis.example.com",
+		Port: "6380",
+	}
+
+	opts, err := BuildOptions(cfg)
+
+	require.NoError(t, err)
+	assert.Equal(t, "redis.example.com:6380", opts.Addr)
+}
+
+func TestBuildOptions_WithPassword(t *testing.T) {
+	t.Parallel()
+
+	cfg := TenantPubSubRedisConfig{
+		Host:     "localhost",
+		Password: "s3cret",
+	}
+
+	opts, err := BuildOptions(cfg)
+
+	require.NoError(t, err)
+	assert.Equal(t, "s3cret", opts.Password)
+}
+
+func TestBuildOptions_WithoutPassword(t *testing.T) {
+	t.Parallel()
+
+	cfg := TenantPubSubRedisConfig{
+		Host: "localhost",
+	}
+
+	opts, err := BuildOptions(cfg)
+
+	require.NoError(t, err)
+	assert.Empty(t, opts.Password)
+}
+
+func TestBuildOptions_WithTLS(t *testing.T) {
+	t.Parallel()
+
+	cfg := TenantPubSubRedisConfig{
+		Host: "redis.example.com",
+		TLS:  true,
+	}
+
+	opts, err := BuildOptions(cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, opts.TLSConfig)
+	assert.Equal(t, uint16(tls.VersionTLS12), opts.TLSConfig.MinVersion)
+}
+
+func TestBuildOptions_WithoutTLS(t *testing.T) {
+	t.Parallel()
+
+	cfg := TenantPubSubRedisConfig{
+		Host: "localhost",
+	}
+
+	opts, err := BuildOptions(cfg)
+
+	require.NoError(t, err)
+	assert.Nil(t, opts.TLSConfig)
+}
+
+func TestBuildOptions_EmptyHost(t *testing.T) {
+	t.Parallel()
+
+	cfg := TenantPubSubRedisConfig{}
+
+	_, err := BuildOptions(cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "host")
+}
+
+func TestBuildOptions_AllFieldsSet(t *testing.T) {
+	t.Parallel()
+
+	cfg := TenantPubSubRedisConfig{
+		Host:     "redis.prod.internal",
+		Port:     "6380",
+		Password: "secret-pass",
+		TLS:      true,
+	}
+
+	opts, err := BuildOptions(cfg)
+
+	require.NoError(t, err)
+	assert.Equal(t, "redis.prod.internal:6380", opts.Addr)
+	assert.Equal(t, "secret-pass", opts.Password)
+	require.NotNil(t, opts.TLSConfig)
+	assert.Equal(t, uint16(tls.VersionTLS12), opts.TLSConfig.MinVersion)
+}


### PR DESCRIPTION
Closes #412

## Summary
- New package `commons/tenant-manager/redis` with `NewTenantPubSubRedisClient` helper
- Centralizes Redis client creation for tenant event Pub/Sub (replaces ~30 lines of duplicated boilerplate in each consumer)
- Adds `MULTI_TENANT_REDIS_TLS` env support — TLS off by default, enabled only when explicitly set to `true`
- Returns `redis.UniversalClient` compatible with `event.NewTenantEventListener`

## New ENV
| Variable | Type | Default | Purpose |
|----------|------|---------|---------|
| `MULTI_TENANT_REDIS_TLS` | bool | `false` | Enable TLS for Pub/Sub Redis (AWS ElastiCache/Valkey) |

## Follow-up (midaz)
Replace duplicated Redis setup in:
- `components/ledger/internal/bootstrap/config.tenant.go`
- `components/crm/internal/bootstrap/config.tenant.go`

## Test plan
- [x] 8 unit tests passing
- [x] Lint: 0 issues