### PR TITLE
fix: harden certificate, dlq, ssrf, idempotency, and webhook paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,11 +132,12 @@ Build and shell:
 
 - `NewManager(certPath, keyPath string) (*Manager, error)` — loads PEM files at construction; if both paths are empty an unconfigured manager is returned (TLS optional). Returns `ErrIncompleteConfig` when exactly one path is provided.
 - Key parsing order: PKCS#8 → PKCS#1 (RSA) → EC (SEC 1). Key file must have mode `0600` or stricter; looser permissions return an error before reading.
-- Atomic hot-reload via `(*Manager).Rotate(cert *x509.Certificate, key crypto.Signer) error` — validates expiry and public-key match before swapping under a write lock.
+- Atomic hot-reload via `(*Manager).Rotate(cert *x509.Certificate, key crypto.Signer, intermediates ...[]byte) error` — validates expiry and public-key match before swapping under a write lock.
 - Sentinel errors: `ErrNilManager`, `ErrCertRequired`, `ErrKeyRequired`, `ErrExpired`, `ErrNoPEMBlock`, `ErrKeyParseFailure`, `ErrNotSigner`, `ErrKeyMismatch`, `ErrIncompleteConfig`.
 - Read accessors (all nil-safe, read-locked): `GetCertificate() *x509.Certificate`, `GetSigner() crypto.Signer`, `PublicKey() crypto.PublicKey`, `ExpiresAt() time.Time`, `DaysUntilExpiry() int`.
 - TLS integration: `TLSCertificate() tls.Certificate` (returns populated `tls.Certificate` struct); `GetCertificateFunc() func(*tls.ClientHelloInfo) (*tls.Certificate, error)` — suitable for assignment to `tls.Config.GetCertificate` for transparent hot-reload.
 - Package-level helper: `LoadFromFiles(certPath, keyPath string) (*x509.Certificate, crypto.Signer, error)` — validates without touching any manager state, useful for pre-flight checking before calling `Rotate`.
+- Package-level helper: `LoadFromFilesWithChain(certPath, keyPath string) (*x509.Certificate, crypto.Signer, [][]byte, error)` — returns the full DER chain for chain-preserving hot-reload.
 
 ### SSRF validation (`commons/security/ssrf`)
 
@@ -192,7 +193,7 @@ Build and shell:
 
 - `New(conn *libRedis.Client, keyPrefix string, maxRetries int, opts ...Option) *Handler` — returns nil when `conn` is nil; all Handler methods guard against a nil receiver with `ErrNilHandler`.
 - Functional options for Handler: `WithLogger`, `WithTracer`, `WithMetrics`, `WithModule`.
-- `DLQMetrics` interface: `RecordRetried(ctx, source)`, `RecordExhausted(ctx, source)` — nil-safe, skipped when not set.
+- `DLQMetrics` interface: `RecordRetried(ctx, source)`, `RecordExhausted(ctx, source)`, `RecordLost(ctx, source)` — a nop implementation is used when not set.
 - Key operations: `Enqueue(ctx, *FailedMessage) error` (RPush), `Dequeue(ctx, source string) (*FailedMessage, error)` (LPop, destructive), `QueueLength(ctx, source string) (int64, error)`.
 - Tenant-scoped Redis keys: `"<prefix><tenantID>:<source>"` (e.g. `"dlq:tenant-abc:outbound"`); falls back to `"<prefix><source>"` when no tenant is in context.
 - `ScanQueues(ctx, source string) ([]string, error)` — uses `SCAN` (non-blocking) to discover all tenant-scoped keys for a source; suitable for background consumers without tenant context.
@@ -211,7 +212,7 @@ Build and shell:
 - Functional options: `WithLogger`, `WithKeyPrefix` (default `"idempotency:"`), `WithKeyTTL` (default 7 days), `WithMaxKeyLength` (default 256), `WithRedisTimeout` (default 500ms), `WithRejectedHandler`, `WithMaxBodyCache` (default 1 MB).
 - `(*Middleware).Check() fiber.Handler` — registers the middleware on a Fiber route.
 - Only applies to mutating methods (POST, PUT, PATCH, DELETE); GET/HEAD/OPTIONS pass through unconditionally.
-- Idempotency key is read from the `Idempotency-Key` request header (`constants.IdempotencyKey`); missing key passes through.
+- Idempotency key is read from the `X-Idempotency` request header (`constants.IdempotencyKey`); missing key passes through.
 - Key too long → 400 JSON `VALIDATION_ERROR` (or custom `WithRejectedHandler`).
 - Redis SetNX atomically claims the key as `"processing"` for the TTL duration.
 - Duplicate request behavior:

--- a/commons/certificate/certificate.go
+++ b/commons/certificate/certificate.go
@@ -101,9 +101,11 @@ func (m *Manager) Rotate(cert *x509.Certificate, key crypto.Signer, intermediate
 		return ErrKeyRequired
 	}
 
-	// Guard against interface wrapping a nil concrete value.
-	pub := key.Public()
-	if pub == nil {
+	// Guard against interface wrapping a nil concrete value. Real crypto types
+	// (ecdsa, rsa, ed25519) panic on nil receiver in Public(), so we recover
+	// rather than relying on the return value check.
+	pub, panicked := safePublic(key)
+	if panicked || pub == nil {
 		return ErrKeyRequired
 	}
 
@@ -167,6 +169,10 @@ func (m *Manager) GetCertificate() *x509.Certificate {
 }
 
 // GetSigner returns the current private key as a crypto.Signer, or nil if none is loaded.
+// The returned signer shares the underlying private key material with the manager (it is
+// NOT a copy). Callers must not modify the concrete key via unsafe type assertions.
+// Ownership of the key is transferred to the manager at [Rotate] time — the caller
+// must not mutate the key after calling Rotate.
 func (m *Manager) GetSigner() crypto.Signer {
 	if m == nil {
 		return nil
@@ -264,7 +270,14 @@ func (m *Manager) TLSCertificate() tls.Certificate {
 // GetCertificateFunc returns a function suitable for use as [tls.Config.GetCertificate].
 // The returned function always serves the most recently loaded certificate, making
 // hot-reload transparent to the TLS layer.
+// Safe to call on a nil receiver (returns a function that always returns [ErrNilManager]).
 func (m *Manager) GetCertificateFunc() func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if m == nil {
+		return func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return nil, ErrNilManager
+		}
+	}
+
 	return func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		cert := m.TLSCertificate()
 		if cert.Certificate == nil {
@@ -377,6 +390,19 @@ func loadFromFiles(certPath, keyPath string) (*x509.Certificate, crypto.Signer, 
 	}
 
 	return cert, signer, certChain, nil
+}
+
+// safePublic calls key.Public() with panic recovery. Real crypto types (ecdsa,
+// rsa, ed25519) panic when called on a nil concrete value behind a non-nil
+// interface. This function converts that panic to a (nil, true) return.
+func safePublic(key crypto.Signer) (pub crypto.PublicKey, panicked bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			panicked = true
+		}
+	}()
+
+	return key.Public(), false
 }
 
 // publicKeysMatch compares two public keys by their DER-encoded PKIX representation.

--- a/commons/certificate/certificate_test.go
+++ b/commons/certificate/certificate_test.go
@@ -830,6 +830,25 @@ func TestNewManager_InvalidCertPath_ErrorSpecificity(t *testing.T) {
 // 10. TestNilManager_SubTests
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// TestLoadFromFilesWithChain — verify chain is returned correctly
+// ---------------------------------------------------------------------------
+
+func TestLoadFromFilesWithChain(t *testing.T) {
+	t.Parallel()
+
+	certPath, keyPath := generateTestCert(t, time.Now().Add(365*24*time.Hour))
+
+	cert, signer, chain, err := LoadFromFilesWithChain(certPath, keyPath)
+	require.NoError(t, err)
+	assert.NotNil(t, cert, "certificate must not be nil")
+	assert.NotNil(t, signer, "signer must not be nil")
+	require.NotNil(t, chain, "chain must not be nil")
+	require.Len(t, chain, 1, "single self-signed cert should produce a 1-element chain")
+	assert.Equal(t, cert.Raw, chain[0],
+		"chain[0] must equal the leaf certificate's raw DER bytes")
+}
+
 func TestNilManager_SubTests(t *testing.T) {
 	t.Parallel()
 

--- a/commons/dlq/consumer.go
+++ b/commons/dlq/consumer.go
@@ -2,7 +2,6 @@ package dlq
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -12,7 +11,6 @@ import (
 	libOtel "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
 	libRuntime "github.com/LerianStudio/lib-commons/v4/commons/runtime"
 	tmcore "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/core"
-	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 )
@@ -148,8 +146,13 @@ func NewConsumer(handler *Handler, retryFn RetryFunc, opts ...ConsumerOption) (*
 	}
 
 	// Inherit handler settings when not overridden via options.
+	// Default to nopDLQMetrics to eliminate nil checks at every call site.
 	if c.metrics == nil {
-		c.metrics = handler.metrics
+		if handler.metrics != nil {
+			c.metrics = handler.metrics
+		} else {
+			c.metrics = nopDLQMetrics{}
+		}
 	}
 
 	if c.module == "" {
@@ -281,7 +284,7 @@ func (c *Consumer) processSource(ctx context.Context, source string) {
 	// Build a context per discovered tenant. Include the bare (non-tenant) context
 	// only when no tenant keys were found — if tenant keys exist, draining the
 	// global (non-tenant) key too would double-process the same logical queue.
-	keyContexts := []context.Context{}
+	var keyContexts []context.Context
 
 	for _, key := range tenantKeys {
 		tenantID := c.handler.ExtractTenantFromKey(key, source)
@@ -404,9 +407,7 @@ func (c *Consumer) processMessage(ctx context.Context, msg *FailedMessage) bool 
 			)
 
 			metricSource := c.sanitizeMetricSource(msg.Source)
-			if c.metrics != nil {
-				c.metrics.RecordLost(ctx, metricSource)
-			}
+			c.metrics.RecordLost(ctx, metricSource)
 
 			return true
 		}
@@ -419,9 +420,7 @@ func (c *Consumer) processMessage(ctx context.Context, msg *FailedMessage) bool 
 		libOtel.HandleSpanError(span, "dlq message exhausted", ErrMessageExhausted)
 
 		metricSource := c.sanitizeMetricSource(msg.Source)
-		if c.metrics != nil {
-			c.metrics.RecordExhausted(ctx, metricSource)
-		}
+		c.metrics.RecordExhausted(ctx, metricSource)
 
 		c.logger.Log(ctx, libLog.LevelError, "dlq consumer: message permanently failed, discarding",
 			libLog.String("source", msg.Source),
@@ -451,9 +450,7 @@ func (c *Consumer) processMessage(ctx context.Context, msg *FailedMessage) bool 
 			)
 
 			metricSource := c.sanitizeMetricSource(msg.Source)
-			if c.metrics != nil {
-				c.metrics.RecordLost(ctx, metricSource)
-			}
+			c.metrics.RecordLost(ctx, metricSource)
 
 			return true
 		}
@@ -469,9 +466,7 @@ func (c *Consumer) processMessage(ctx context.Context, msg *FailedMessage) bool 
 
 	// Retry succeeded — record metric and discard.
 	metricSource := c.sanitizeMetricSource(msg.Source)
-	if c.metrics != nil {
-		c.metrics.RecordRetried(ctx, metricSource)
-	}
+	c.metrics.RecordRetried(ctx, metricSource)
 
 	c.logger.Log(ctx, libLog.LevelInfo, "dlq consumer: message retry succeeded",
 		libLog.String("source", msg.Source),
@@ -509,10 +504,4 @@ func (c *Consumer) sanitizeMetricSource(source string) string {
 	}
 
 	return "unknown"
-}
-
-// isRedisNilError reports whether err wraps redis.Nil. The Handler uses
-// fmt.Errorf("%w") so errors.Is unwraps correctly through the chain.
-func isRedisNilError(err error) bool {
-	return errors.Is(err, redis.Nil)
 }

--- a/commons/dlq/consumer_test.go
+++ b/commons/dlq/consumer_test.go
@@ -659,6 +659,55 @@ func TestNewConsumer_NilOptions(t *testing.T) {
 	assert.NotNil(t, c.tracer, "tracer must remain non-nil")
 }
 
+// TestProcessOnce_RetryFuncPanics verifies that if the caller-provided retryFn
+// panics, the consumer recovers gracefully: the test does not crash, and the
+// message is re-enqueued with an incremented retry count so it is not lost.
+func TestProcessOnce_RetryFuncPanics(t *testing.T) {
+	t.Parallel()
+
+	metrics := &mockMetrics{}
+
+	retryFn := func(_ context.Context, _ *FailedMessage) error {
+		panic("boom from retryFn")
+	}
+
+	c, h, mr := newTestConsumer(t, retryFn, metrics)
+
+	ctx := tmcore.ContextWithTenantID(context.Background(), "tenant-panic")
+
+	// Inject a retryable message with a past NextRetryAt so the consumer
+	// considers it immediately eligible for retry.
+	injectMessage(t, mr, "dlq:tenant-panic:outbound", &FailedMessage{
+		Source:       "outbound",
+		OriginalData: []byte(`{"id":"panic-msg"}`),
+		ErrorMessage: "original error",
+		RetryCount:   0,
+		MaxRetries:   3,
+		CreatedAt:    time.Now().UTC().Add(-5 * time.Minute),
+		NextRetryAt:  time.Now().UTC().Add(-1 * time.Minute),
+		TenantID:     "tenant-panic",
+	})
+
+	// ProcessOnce must not panic — the safeRetryFunc wrapper recovers.
+	require.NotPanics(t, func() {
+		c.ProcessOnce(ctx)
+	}, "ProcessOnce must not propagate a panic from retryFn")
+
+	// The message must be re-enqueued (not lost) with an incremented RetryCount.
+	length, err := h.QueueLength(ctx, "outbound")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), length,
+		"message must be re-enqueued after retryFn panic, not lost")
+
+	// Dequeue and verify the retry count was incremented.
+	msg, err := h.Dequeue(ctx, "outbound")
+	require.NoError(t, err)
+	assert.Equal(t, 1, msg.RetryCount,
+		"RetryCount must be incremented after panic-recovered retry failure")
+	assert.Contains(t, msg.ErrorMessage, "panicked",
+		"ErrorMessage must indicate the panic was recovered")
+}
+
 // TestIsRedisNilError covers the four cases for isRedisNilError:
 // direct redis.Nil sentinel, wrapped sentinel, arbitrary error, and nil.
 func TestIsRedisNilError(t *testing.T) {

--- a/commons/dlq/handler.go
+++ b/commons/dlq/handler.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"time"
-	"unicode/utf8"
 
 	libBackoff "github.com/LerianStudio/lib-commons/v4/commons/backoff"
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
@@ -18,12 +17,21 @@ import (
 )
 
 // DLQMetrics records DLQ-specific counters. Implementations are optional;
-// when nil, metric calls are silently skipped.
+// when nil or not provided, a noop implementation is used.
 type DLQMetrics interface {
 	RecordRetried(ctx context.Context, source string)
 	RecordExhausted(ctx context.Context, source string)
 	RecordLost(ctx context.Context, source string)
 }
+
+// nopDLQMetrics is a no-op implementation of DLQMetrics that silently discards
+// all metric calls. Used as the default when no metrics implementation is provided,
+// eliminating nil checks at every call site.
+type nopDLQMetrics struct{}
+
+func (nopDLQMetrics) RecordRetried(context.Context, string)   {}
+func (nopDLQMetrics) RecordExhausted(context.Context, string) {}
+func (nopDLQMetrics) RecordLost(context.Context, string)      {}
 
 // FailedMessage represents a message that failed processing and was routed to
 // the dead letter queue for later retry.
@@ -101,7 +109,7 @@ func New(conn *libRedis.Client, keyPrefix string, maxRetries int, opts ...Option
 	}
 
 	if maxRetries <= 0 {
-		maxRetries = 3
+		maxRetries = 3 //nolint:mnd // sensible default when caller passes zero or negative
 	}
 
 	if keyPrefix == "" {
@@ -456,97 +464,4 @@ func (h *Handler) PruneExhaustedMessages(ctx context.Context, source string, lim
 	}
 
 	return pruned, nil
-}
-
-// ExtractTenantFromKey extracts the tenant ID from a tenant-scoped Redis key.
-// Given key="dlq:tenant-abc:outbound" and keyPrefix="dlq:", returns "tenant-abc".
-// Returns empty string if the key does not match the expected format.
-func (h *Handler) ExtractTenantFromKey(key, source string) string {
-	if h == nil {
-		return ""
-	}
-
-	prefix := h.keyPrefix
-	suffix := ":" + source
-
-	if len(key) <= len(prefix)+len(suffix) {
-		return ""
-	}
-
-	if key[:len(prefix)] != prefix {
-		return ""
-	}
-
-	if key[len(key)-len(suffix):] != suffix {
-		return ""
-	}
-
-	return key[len(prefix) : len(key)-len(suffix)]
-}
-
-// tenantScopedKey constructs a Redis key including the tenant ID from context.
-// With tenant:    "dlq:tenant-abc:outbound"
-// Without tenant: "dlq:outbound"
-func (h *Handler) tenantScopedKey(ctx context.Context, source string) string {
-	return h.tenantScopedKeyForTenant(tmcore.GetTenantIDContext(ctx), source)
-}
-
-func (h *Handler) tenantScopedKeyForTenant(tenantID, source string) string {
-	if tenantID != "" {
-		if err := validateKeySegment("tenantID", tenantID); err != nil {
-			// Log the invalid segment and fall back to the non-tenant key
-			// rather than constructing a corrupted Redis key.
-			h.logger.Log(context.Background(), libLog.LevelWarn, "dlq: tenantScopedKeyForTenant: invalid tenantID, using global key",
-				libLog.String("tenant_id", tenantID),
-				libLog.Err(err),
-			)
-
-			return fmt.Sprintf("%s%s", h.keyPrefix, source)
-		}
-
-		return fmt.Sprintf("%s%s:%s", h.keyPrefix, tenantID, source)
-	}
-
-	return fmt.Sprintf("%s%s", h.keyPrefix, source)
-}
-
-// validateKeySegment ensures that a Redis key segment (source or tenantID)
-// does not contain characters that would corrupt key patterns or enable
-// injection into SCAN glob patterns. Backslash is included because it is
-// the escape character in Redis SCAN patterns.
-func validateKeySegment(name, value string) error {
-	for _, c := range value {
-		if c == ':' || c == '*' || c == '?' || c == '[' || c == ']' || c == '\\' {
-			return fmt.Errorf("dlq: %s %q contains disallowed character %q", name, value, c)
-		}
-	}
-
-	return nil
-}
-
-// truncateString returns s unchanged when its rune count is within maxLen,
-// otherwise it truncates at the maxLen-th rune boundary and appends "..."
-// to signal that content was trimmed. Rune-aware truncation prevents
-// splitting multi-byte UTF-8 sequences, which would produce invalid output.
-// Used by logEnqueueFallback to prevent large PII-containing error messages
-// from leaking into log aggregators.
-func truncateString(s string, maxLen int) string {
-	if utf8.RuneCountInString(s) <= maxLen {
-		return s
-	}
-
-	// Walk runes and cut at the correct byte offset.
-	byteLen := 0
-	count := 0
-
-	for _, r := range s {
-		if count == maxLen {
-			break
-		}
-
-		byteLen += utf8.RuneLen(r)
-		count++
-	}
-
-	return s[:byteLen] + "..."
 }

--- a/commons/dlq/keys.go
+++ b/commons/dlq/keys.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Lerian Studio.
+
+package dlq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"unicode/utf8"
+
+	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
+	tmcore "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/core"
+	"github.com/redis/go-redis/v9"
+)
+
+// tenantScopedKey constructs a Redis key including the tenant ID from context.
+// With tenant:    "dlq:tenant-abc:outbound"
+// Without tenant: "dlq:outbound"
+func (h *Handler) tenantScopedKey(ctx context.Context, source string) string {
+	return h.tenantScopedKeyForTenant(tmcore.GetTenantIDContext(ctx), source)
+}
+
+func (h *Handler) tenantScopedKeyForTenant(tenantID, source string) string {
+	if tenantID != "" {
+		if err := validateKeySegment("tenantID", tenantID); err != nil {
+			// Log the invalid segment and fall back to the non-tenant key
+			// rather than constructing a corrupted Redis key.
+			h.logger.Log(context.Background(), libLog.LevelWarn, "dlq: tenantScopedKeyForTenant: invalid tenantID, using global key",
+				libLog.String("tenant_id", tenantID),
+				libLog.Err(err),
+			)
+
+			return fmt.Sprintf("%s%s", h.keyPrefix, source)
+		}
+
+		return fmt.Sprintf("%s%s:%s", h.keyPrefix, tenantID, source)
+	}
+
+	return fmt.Sprintf("%s%s", h.keyPrefix, source)
+}
+
+// ExtractTenantFromKey extracts the tenant ID from a tenant-scoped Redis key.
+// Given key="dlq:tenant-abc:outbound" and keyPrefix="dlq:", returns "tenant-abc".
+// Returns empty string if the key does not match the expected format.
+func (h *Handler) ExtractTenantFromKey(key, source string) string {
+	if h == nil {
+		return ""
+	}
+
+	prefix := h.keyPrefix
+	suffix := ":" + source
+
+	if len(key) <= len(prefix)+len(suffix) {
+		return ""
+	}
+
+	if key[:len(prefix)] != prefix {
+		return ""
+	}
+
+	if key[len(key)-len(suffix):] != suffix {
+		return ""
+	}
+
+	return key[len(prefix) : len(key)-len(suffix)]
+}
+
+// validateKeySegment ensures that a Redis key segment (source or tenantID)
+// does not contain characters that would corrupt key patterns or enable
+// injection into SCAN glob patterns. Backslash is included because it is
+// the escape character in Redis SCAN patterns.
+func validateKeySegment(name, value string) error {
+	for _, c := range value {
+		if c == ':' || c == '*' || c == '?' || c == '[' || c == ']' || c == '\\' {
+			return fmt.Errorf("dlq: %s %q contains disallowed character %q", name, value, c)
+		}
+	}
+
+	return nil
+}
+
+// truncateString returns s unchanged when its rune count is within maxLen,
+// otherwise it truncates at the maxLen-th rune boundary and appends "..."
+// to signal that content was trimmed. Rune-aware truncation prevents
+// splitting multi-byte UTF-8 sequences, which would produce invalid output.
+// Used by logEnqueueFallback to prevent large PII-containing error messages
+// from leaking into log aggregators.
+func truncateString(s string, maxLen int) string {
+	if utf8.RuneCountInString(s) <= maxLen {
+		return s
+	}
+
+	// Walk runes and cut at the correct byte offset.
+	byteLen := 0
+	count := 0
+
+	for _, r := range s {
+		if count == maxLen {
+			break
+		}
+
+		byteLen += utf8.RuneLen(r)
+		count++
+	}
+
+	return s[:byteLen] + "..."
+}
+
+// isRedisNilError reports whether err wraps redis.Nil. The Handler uses
+// fmt.Errorf("%w") so errors.Is unwraps correctly through the chain.
+func isRedisNilError(err error) bool {
+	return errors.Is(err, redis.Nil)
+}

--- a/commons/net/http/idempotency/idempotency.go
+++ b/commons/net/http/idempotency/idempotency.go
@@ -356,6 +356,12 @@ func (m *Middleware) saveResult(
 
 			if data, marshalErr := json.Marshal(resp); marshalErr == nil {
 				pipe.Set(ctx, responseKey, string(data), m.keyTTL)
+			} else {
+				m.logger.Log(ctx, log.LevelWarn,
+					"idempotency: failed to marshal cached response",
+					log.Err(marshalErr),
+					log.String("idempotency_key_hash", redactKey(key)),
+				)
 			}
 		} else {
 			m.logger.Log(ctx, log.LevelWarn,

--- a/commons/net/http/idempotency/idempotency_test.go
+++ b/commons/net/http/idempotency/idempotency_test.go
@@ -795,6 +795,62 @@ func TestCheck_HeadRequest_PassesThrough(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// PUT method enforcement — idempotency applies to all mutating methods
+// ---------------------------------------------------------------------------
+
+// TestCheck_PUTRequest_Enforced verifies that PUT requests are subject to
+// idempotency enforcement: the first PUT proceeds to the handler and the
+// second PUT with the same key replays the cached response.
+func TestCheck_PUTRequest_Enforced(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	conn := newRedisClient(t, mr)
+	m := New(conn)
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Use(tenantMiddleware("tenant-put"))
+	app.Use(m.Check())
+	app.Put("/resource", func(c *fiber.Ctx) error {
+		return c.Status(fiber.StatusOK).JSON(fiber.Map{"updated": true})
+	})
+
+	doPut := func(key string) *http.Response {
+		t.Helper()
+
+		req := httptest.NewRequest(http.MethodPut, "/resource", nil)
+		if key != "" {
+			req.Header.Set(chttp.IdempotencyKey, key)
+		}
+
+		resp, err := app.Test(req, -1)
+		require.NoError(t, err)
+
+		return resp
+	}
+
+	// First PUT — should reach the handler.
+	resp1 := doPut("put-key-1")
+	body1 := readBody(t, resp1)
+
+	assert.Equal(t, http.StatusOK, resp1.StatusCode)
+	assert.Contains(t, body1, "updated")
+	assert.Empty(t, resp1.Header.Get(chttp.IdempotencyReplayed),
+		"first request must not be marked as replayed")
+
+	// Second PUT — same key — must replay the cached response.
+	resp2 := doPut("put-key-1")
+	body2 := readBody(t, resp2)
+
+	assert.Equal(t, http.StatusOK, resp2.StatusCode,
+		"replayed response must have the original status code")
+	assert.Contains(t, body2, "updated",
+		"replayed response must have the original body")
+	assert.Equal(t, "true", resp2.Header.Get(chttp.IdempotencyReplayed),
+		"replayed response must set Idempotency-Replayed: true")
+}
+
+// ---------------------------------------------------------------------------
 // Negative option values — defaults must be preserved
 // ---------------------------------------------------------------------------
 

--- a/commons/net/http/proxy_transport.go
+++ b/commons/net/http/proxy_transport.go
@@ -11,10 +11,12 @@ import (
 	"github.com/LerianStudio/lib-commons/v4/commons/log"
 )
 
-// TODO(ssrf): Migrate to ssrf.ResolveAndValidate for full DNS-pinned flow to
-// eliminate the TOCTOU window between IP validation and connection. Currently
-// only IP validation is delegated to the canonical ssrf package; DNS resolution
-// and pinning are not. See commons/security/ssrf/validate.go:ResolveAndValidate.
+// TODO(ssrf): Migrate to ssrf.ResolveAndValidate to eliminate the remaining
+// TOCTOU window between validating resolved IPs and dialing them. This
+// transport already resolves DNS and pins the connection to the selected IP by
+// rewriting addr to safeIP.String(), but resolution/validation still happens
+// outside the canonical ssrf flow instead of being centralized in
+// commons/security/ssrf/validate.go:ResolveAndValidate.
 
 // ssrfSafeTransport wraps an http.Transport with a DialContext that validates
 // resolved IP addresses against the SSRF policy at connection time.

--- a/commons/net/http/proxy_transport.go
+++ b/commons/net/http/proxy_transport.go
@@ -11,6 +11,11 @@ import (
 	"github.com/LerianStudio/lib-commons/v4/commons/log"
 )
 
+// TODO(ssrf): Migrate to ssrf.ResolveAndValidate for full DNS-pinned flow to
+// eliminate the TOCTOU window between IP validation and connection. Currently
+// only IP validation is delegated to the canonical ssrf package; DNS resolution
+// and pinning are not. See commons/security/ssrf/validate.go:ResolveAndValidate.
+
 // ssrfSafeTransport wraps an http.Transport with a DialContext that validates
 // resolved IP addresses against the SSRF policy at connection time.
 // This prevents DNS rebinding attacks where a hostname resolves to a safe IP

--- a/commons/security/ssrf/hostname.go
+++ b/commons/security/ssrf/hostname.go
@@ -12,6 +12,9 @@ var blockedHostnames = map[string]bool{
 	"metadata.gcp.internal":    true,
 	// AWS metadata IP as a hostname (also caught by IP check — defense-in-depth).
 	"169.254.169.254": true,
+	// Azure Instance Metadata Service (also caught by IP check and .internal
+	// suffix — defense-in-depth).
+	"metadata.azure.internal": true,
 }
 
 // blockedSuffixes contains hostname suffixes that indicate internal or

--- a/commons/security/ssrf/options.go
+++ b/commons/security/ssrf/options.go
@@ -36,7 +36,9 @@ func buildConfig(opts []Option) *config {
 	cfg := &config{}
 
 	for _, opt := range opts {
-		opt(cfg)
+		if opt != nil {
+			opt(cfg)
+		}
 	}
 
 	return cfg
@@ -64,7 +66,9 @@ func WithAllowPrivateNetwork() Option {
 // all IPs blocked, mixed safe/blocked IPs).
 func WithLookupFunc(fn LookupFunc) Option {
 	return func(c *config) {
-		c.lookupFunc = fn
+		if fn != nil {
+			c.lookupFunc = fn
+		}
 	}
 }
 

--- a/commons/security/ssrf/ssrf.go
+++ b/commons/security/ssrf/ssrf.go
@@ -38,6 +38,10 @@ var blockedPrefixes = []netip.Prefix{
 	netip.MustParsePrefix("198.51.100.0/24"), // TEST-NET-2 documentation (RFC 5737)
 	netip.MustParsePrefix("203.0.113.0/24"),  // TEST-NET-3 documentation (RFC 5737)
 	netip.MustParsePrefix("240.0.0.0/4"),     // reserved / future use (RFC 1112)
+
+	// IPv6 special-purpose ranges not covered by stdlib predicates.
+	netip.MustParsePrefix("2001:db8::/32"), // documentation (RFC 3849)
+	netip.MustParsePrefix("100::/64"),      // discard-only (RFC 6666)
 }
 
 // BlockedPrefixes returns a copy of the canonical CIDR blocklist. The returned

--- a/commons/security/ssrf/ssrf_test.go
+++ b/commons/security/ssrf/ssrf_test.go
@@ -399,6 +399,15 @@ func TestValidateURL_MalformedURL(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidURL)
 }
 
+func TestValidateURL_NilContext(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateURL(nil, "https://example.com/hook")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidURL)
+	assert.Contains(t, err.Error(), "nil context")
+}
+
 func TestValidateURL_HTTPSOnly(t *testing.T) {
 	t.Parallel()
 

--- a/commons/security/ssrf/ssrf_test.go
+++ b/commons/security/ssrf/ssrf_test.go
@@ -20,7 +20,7 @@ import (
 // expectedPrefixCount lives in the test file so the production code does not
 // export or carry a constant that is only meaningful for test assertions.
 // Update this value when adding new CIDR ranges to blockedPrefixes.
-const expectedPrefixCount = 8
+const expectedPrefixCount = 10
 
 func TestBlockedPrefixes_ReturnsExpectedCount(t *testing.T) {
 	t.Parallel()
@@ -54,6 +54,8 @@ func TestBlockedPrefixes_ContainsExpectedRanges(t *testing.T) {
 		"198.51.100.0/24",
 		"203.0.113.0/24",
 		"240.0.0.0/4",
+		"2001:db8::/32",
+		"100::/64",
 	}
 
 	prefixes := BlockedPrefixes()
@@ -888,6 +890,30 @@ func TestIsBlockedHostnameWithConfig_AllowOverride(t *testing.T) {
 // ---------------------------------------------------------------------------
 // Error sentinel identity
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// IPv6 special-purpose ranges — documentation and discard
+// ---------------------------------------------------------------------------
+
+// TestIsBlockedAddr_IPv6_DocumentationRange verifies that addresses in the
+// IPv6 documentation range 2001:db8::/32 (RFC 3849) are blocked.
+func TestIsBlockedAddr_IPv6_DocumentationRange(t *testing.T) {
+	t.Parallel()
+
+	addr := netip.MustParseAddr("2001:db8::1")
+	assert.True(t, IsBlockedAddr(addr),
+		"IPv6 documentation address 2001:db8::1 must be blocked (RFC 3849)")
+}
+
+// TestIsBlockedAddr_IPv6_DiscardRange verifies that addresses in the
+// IPv6 discard-only range 100::/64 (RFC 6666) are blocked.
+func TestIsBlockedAddr_IPv6_DiscardRange(t *testing.T) {
+	t.Parallel()
+
+	addr := netip.MustParseAddr("100::1")
+	assert.True(t, IsBlockedAddr(addr),
+		"IPv6 discard-only address 100::1 must be blocked (RFC 6666)")
+}
 
 func TestSentinelErrors_AreDistinct(t *testing.T) {
 	t.Parallel()

--- a/commons/security/ssrf/ssrf_test.go
+++ b/commons/security/ssrf/ssrf_test.go
@@ -673,6 +673,33 @@ func TestResolveAndValidate_MalformedURL(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidURL)
 }
 
+func TestResolveAndValidate_NilContext(t *testing.T) {
+	t.Parallel()
+
+	_, err := ResolveAndValidate(nil, "https://example.com/hook",
+		WithLookupFunc(fakeLookup("93.184.216.34")),
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidURL)
+	assert.Contains(t, err.Error(), "nil context")
+}
+
+func TestResolveAndValidate_CanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ResolveAndValidate(ctx, "https://example.com/hook",
+		WithLookupFunc(fakeLookup("93.184.216.34")),
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidURL)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 func TestResolveAndValidate_HTTPSOnly(t *testing.T) {
 	t.Parallel()
 

--- a/commons/security/ssrf/validate.go
+++ b/commons/security/ssrf/validate.go
@@ -99,6 +99,14 @@ func ValidateURL(ctx context.Context, rawURL string, opts ...Option) error {
 // Errors wrap [ErrBlocked], [ErrInvalidURL], or [ErrDNSFailed] for
 // programmatic inspection via [errors.Is].
 func ResolveAndValidate(ctx context.Context, rawURL string, opts ...Option) (*ResolveResult, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidURL, errors.New("nil context"))
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidURL, err)
+	}
+
 	cfg := buildConfig(opts)
 
 	u, err := url.Parse(rawURL)

--- a/commons/security/ssrf/validate.go
+++ b/commons/security/ssrf/validate.go
@@ -2,6 +2,7 @@ package ssrf
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -39,6 +40,10 @@ type ResolveResult struct {
 // Errors wrap [ErrBlocked] or [ErrInvalidURL] for programmatic inspection via
 // [errors.Is].
 func ValidateURL(ctx context.Context, rawURL string, opts ...Option) error {
+	if ctx == nil {
+		return fmt.Errorf("%w: %w", ErrInvalidURL, errors.New("nil context"))
+	}
+
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidURL, err)
 	}

--- a/commons/security/ssrf/validate.go
+++ b/commons/security/ssrf/validate.go
@@ -39,7 +39,9 @@ type ResolveResult struct {
 // Errors wrap [ErrBlocked] or [ErrInvalidURL] for programmatic inspection via
 // [errors.Is].
 func ValidateURL(ctx context.Context, rawURL string, opts ...Option) error {
-	_ = ctx // TODO(ssrf): use ctx for tracing/metrics integration when telemetry is wired in
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidURL, err)
+	}
 
 	cfg := buildConfig(opts)
 

--- a/commons/security/ssrf/validate.go
+++ b/commons/security/ssrf/validate.go
@@ -40,12 +40,8 @@ type ResolveResult struct {
 // Errors wrap [ErrBlocked] or [ErrInvalidURL] for programmatic inspection via
 // [errors.Is].
 func ValidateURL(ctx context.Context, rawURL string, opts ...Option) error {
-	if ctx == nil {
-		return fmt.Errorf("%w: %w", ErrInvalidURL, errors.New("nil context"))
-	}
-
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("%w: %w", ErrInvalidURL, err)
+	if err := validateContext(ctx); err != nil {
+		return err
 	}
 
 	cfg := buildConfig(opts)
@@ -99,12 +95,8 @@ func ValidateURL(ctx context.Context, rawURL string, opts ...Option) error {
 // Errors wrap [ErrBlocked], [ErrInvalidURL], or [ErrDNSFailed] for
 // programmatic inspection via [errors.Is].
 func ResolveAndValidate(ctx context.Context, rawURL string, opts ...Option) (*ResolveResult, error) {
-	if ctx == nil {
-		return nil, fmt.Errorf("%w: %w", ErrInvalidURL, errors.New("nil context"))
-	}
-
-	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrInvalidURL, err)
+	if err := validateContext(ctx); err != nil {
+		return nil, err
 	}
 
 	cfg := buildConfig(opts)
@@ -182,6 +174,18 @@ func ResolveAndValidate(ctx context.Context, rawURL string, opts ...Option) (*Re
 		Authority:   authority,
 		SNIHostname: hostname,
 	}, nil
+}
+
+func validateContext(ctx context.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("%w: %w", ErrInvalidURL, errors.New("nil context"))
+	}
+
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidURL, err)
+	}
+
+	return nil
 }
 
 // validateScheme checks that the URL scheme is allowed. By default only "http"

--- a/commons/systemplane/adapters/http/fiber/dto.go
+++ b/commons/systemplane/adapters/http/fiber/dto.go
@@ -50,6 +50,13 @@ type SchemaResponse struct {
 }
 
 // SchemaEntryDTO represents a single key's metadata in the schema response.
+//
+// Security note: the EnvVar field exposes environment variable names (e.g.
+// POSTGRES_PASSWORD) to authenticated users with schema read permissions.
+// While values are always redacted for secret keys, the variable names
+// themselves reveal infrastructure topology. This is an accepted trade-off:
+// the schema endpoint requires authentication + authorization, and operators
+// need env var names for configuration management.
 type SchemaEntryDTO struct {
 	Key              string   `json:"key"`
 	EnvVar           string   `json:"envVar,omitempty"`

--- a/commons/webhook/deliverer.go
+++ b/commons/webhook/deliverer.go
@@ -3,10 +3,7 @@ package webhook
 import (
 	"bytes"
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
 	"crypto/tls"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -26,21 +23,6 @@ import (
 	"github.com/LerianStudio/lib-commons/v4/commons/runtime"
 )
 
-// SignatureVersion controls the HMAC signing format used for X-Webhook-Signature.
-type SignatureVersion int
-
-const (
-	// SignatureV0 produces legacy payload-only signatures: "sha256=<hex(HMAC(payload))>".
-	// This is the default for backward compatibility with existing consumers.
-	SignatureV0 SignatureVersion = iota
-
-	// SignatureV1 produces versioned timestamp-bound signatures:
-	// "v1,sha256=<hex(HMAC(v1:<timestamp>.<payload>))>".
-	// The timestamp is included in the HMAC input to prevent replay attacks.
-	// Receivers must verify freshness (e.g., reject timestamps older than 5 minutes).
-	SignatureV1
-)
-
 // Defaults for Deliverer configuration.
 const (
 	defaultMaxConcurrency = 20
@@ -50,6 +32,10 @@ const (
 	defaultMaxIdleConns   = 100
 	defaultIdlePerHost    = 10
 	defaultIdleTimeout    = 90 * time.Second
+	// maxResponseDrain limits how much of the response body is read and
+	// discarded after delivery. This ensures the underlying TCP connection
+	// can be reused by the connection pool.
+	maxResponseDrain = 64 << 10 // 64 KiB
 )
 
 // Deliverer sends webhook events to registered endpoints with SSRF protection,
@@ -140,7 +126,9 @@ func WithHTTPClient(c *http.Client) Option {
 // be skipped with an error (fail-closed).
 func WithSecretDecryptor(fn SecretDecryptor) Option {
 	return func(d *Deliverer) {
-		d.decryptor = fn
+		if fn != nil {
+			d.decryptor = fn
+		}
 	}
 }
 
@@ -298,6 +286,9 @@ func (d *Deliverer) fanOut(ctx context.Context, endpoints []Endpoint, event *Eve
 
 		sem <- struct{}{}
 
+		// Detach from parent cancel so in-flight deliveries complete during
+		// graceful shutdown. The wg.Wait() in the caller ensures all goroutines
+		// finish before Deliver/DeliverWithResults returns.
 		dlvCtx := context.WithoutCancel(ctx)
 
 		go func() {
@@ -333,6 +324,7 @@ func (d *Deliverer) fanOutWithResults(
 
 		sem <- struct{}{}
 
+		// Detach from parent cancel — see fanOut for rationale.
 		dlvCtx := context.WithoutCancel(ctx)
 
 		// Pre-populate so callers always see which endpoint was attempted,
@@ -418,6 +410,8 @@ func (d *Deliverer) deliverToEndpoint(
 		result.StatusCode = statusCode
 
 		if err != nil {
+			result.Error = err // preserve last transport error for diagnostics
+
 			d.log(ctx, log.LevelWarn, "webhook delivery failed",
 				log.String("url", sanitizeURL(ep.URL)),
 				log.Int("attempt", attempt+1),
@@ -440,6 +434,14 @@ func (d *Deliverer) deliverToEndpoint(
 			return result
 		}
 
+		// 3xx responses: redirect blocked by CheckRedirect — not a transient error.
+		if statusCode >= http.StatusMultipleChoices && statusCode < http.StatusBadRequest {
+			result.Error = fmt.Errorf("webhook: non-retryable redirect status %d (redirects blocked)", statusCode)
+			d.recordMetrics(ctx, ep.ID, false, statusCode, result.Attempts)
+
+			return result
+		}
+
 		// Non-retryable client errors — break immediately (except 429 Too Many Requests).
 		if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError && statusCode != http.StatusTooManyRequests {
 			result.Error = fmt.Errorf("webhook: non-retryable status %d", statusCode)
@@ -455,8 +457,13 @@ func (d *Deliverer) deliverToEndpoint(
 		)
 	}
 
-	// Exhausted all retries.
-	result.Error = fmt.Errorf("%w: exhausted %d attempts for %s", ErrDeliveryFailed, d.maxRetries+1, sanitizeURL(ep.URL))
+	// Exhausted all retries. Wrap the last transport error (if any) for diagnostics.
+	if result.Error != nil {
+		result.Error = fmt.Errorf("%w: exhausted %d attempts for %s (last error: %w)", ErrDeliveryFailed, d.maxRetries+1, sanitizeURL(ep.URL), result.Error)
+	} else {
+		result.Error = fmt.Errorf("%w: exhausted %d attempts for %s", ErrDeliveryFailed, d.maxRetries+1, sanitizeURL(ep.URL))
+	}
+
 	d.recordMetrics(ctx, ep.ID, false, result.StatusCode, result.Attempts)
 
 	span.RecordError(result.Error)
@@ -519,7 +526,7 @@ func (d *Deliverer) doHTTP(
 		return 0, fmt.Errorf("webhook: http request: %w", err)
 	}
 
-	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxResponseDrain))
 	_ = resp.Body.Close()
 
 	return resp.StatusCode, nil
@@ -557,106 +564,6 @@ func (d *Deliverer) computeSignature(payload []byte, timestamp int64, secret str
 	default:
 		return "sha256=" + computeHMAC(payload, secret)
 	}
-}
-
-// computeHMAC returns the hex-encoded HMAC-SHA256 of payload using the given secret.
-// This is the legacy (v0) format that signs the raw payload only.
-//
-// Design note — timestamp not included in v0 signature (by intent):
-// The signature covers the raw payload only, not the X-Webhook-Timestamp value.
-// This format is maintained for backward compatibility. New deployments should
-// prefer SignatureV1 (via WithSignatureVersion) which binds the timestamp into
-// the HMAC input to enable replay protection.
-func computeHMAC(payload []byte, secret string) string {
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write(payload)
-
-	return hex.EncodeToString(mac.Sum(nil))
-}
-
-// computeHMACv1 returns a versioned signature string:
-//
-//	"v1,sha256=<hex(HMAC-SHA256("v1:<timestamp>.<payload>", secret))>"
-//
-// The version prefix "v1:" followed by the decimal timestamp and a dot separator
-// are prepended to the payload before computing the HMAC, binding the timestamp
-// to the signature. Receivers must parse the "v1," prefix, extract the timestamp
-// from the X-Webhook-Timestamp header, reconstruct the signing input, and verify
-// the HMAC before accepting the webhook.
-func computeHMACv1(payload []byte, timestamp int64, secret string) string {
-	ts := strconv.FormatInt(timestamp, 10)
-
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte("v1:"))
-	mac.Write([]byte(ts))
-	mac.Write([]byte("."))
-	mac.Write(payload)
-
-	return "v1,sha256=" + hex.EncodeToString(mac.Sum(nil))
-}
-
-// VerifySignature verifies a webhook signature by auto-detecting the version
-// from the signature string format. Returns nil on valid signature, or an error
-// describing the mismatch.
-//
-// Supported formats:
-//   - "sha256=<hex>"          — v0 (payload-only)
-//   - "v1,sha256=<hex>"       — v1 (timestamp-bound)
-//
-// For v1 signatures, the timestamp parameter is required to reconstruct the
-// signing input. For v0 signatures, the timestamp is ignored.
-func VerifySignature(payload []byte, timestamp int64, secret, signature string) error {
-	switch {
-	case strings.HasPrefix(signature, "v1,"):
-		expected := computeHMACv1(payload, timestamp, secret)
-		if !hmac.Equal([]byte(signature), []byte(expected)) {
-			return errors.New("webhook: v1 signature mismatch")
-		}
-
-		return nil
-
-	case strings.HasPrefix(signature, "sha256="):
-		expected := "sha256=" + computeHMAC(payload, secret)
-		if !hmac.Equal([]byte(signature), []byte(expected)) {
-			return errors.New("webhook: v0 signature mismatch")
-		}
-
-		return nil
-
-	default:
-		return errors.New("webhook: unrecognized signature format")
-	}
-}
-
-// VerifySignatureWithFreshness verifies a v1 webhook signature and additionally
-// checks that the timestamp is within the given tolerance window from now.
-// This provides replay protection: even if an attacker captures a valid
-// payload+signature pair, it becomes invalid after the tolerance window expires.
-//
-// For v0 ("sha256=...") signatures, freshness cannot be enforced because the
-// timestamp is not covered by the HMAC. Callers receiving v0 signatures should
-// use VerifySignature and implement replay protection independently (e.g.,
-// idempotency keys or event-ID tracking).
-func VerifySignatureWithFreshness(payload []byte, timestamp int64, secret, signature string, tolerance time.Duration) error {
-	if err := VerifySignature(payload, timestamp, secret, signature); err != nil {
-		return err
-	}
-
-	// Freshness check only applies to v1 where the timestamp is signed.
-	if strings.HasPrefix(signature, "v1,") {
-		eventTime := time.Unix(timestamp, 0)
-		delta := time.Since(eventTime)
-
-		if delta < 0 {
-			delta = -delta
-		}
-
-		if delta > tolerance {
-			return fmt.Errorf("webhook: timestamp outside tolerance window (%s > %s)", delta.Truncate(time.Second), tolerance)
-		}
-	}
-
-	return nil
 }
 
 // filterActive returns only endpoints where Active is true.
@@ -705,6 +612,10 @@ func (d *Deliverer) recordMetrics(ctx context.Context, endpointID string, succes
 
 	d.metrics.RecordDelivery(ctx, endpointID, success, statusCode, attempts)
 }
+
+// TODO(perf): Cache pinned transports by SNI hostname using sync.Map to avoid
+// creating a new connection pool on every HTTPS delivery. Currently transport.Clone()
+// is called per request, which negates connection pooling for HTTPS pinned URLs.
 
 // httpsClientForPinnedIP returns an HTTP client whose TLS config uses the
 // given hostname for SNI and certificate verification. This is necessary

--- a/commons/webhook/deliverer_test.go
+++ b/commons/webhook/deliverer_test.go
@@ -1098,6 +1098,76 @@ func TestVerifySignatureWithFreshness(t *testing.T) {
 	assert.NoError(t, err, "v0 signature skips freshness check")
 }
 
+// ---------------------------------------------------------------------------
+// HTTP 429 (Too Many Requests) — must be retried, not short-circuited
+// ---------------------------------------------------------------------------
+
+// TestDeliver_429_IsRetried verifies that a 429 Too Many Requests response is
+// retried (unlike other 4xx which short-circuit). The server returns 429 twice,
+// then 200 on the third attempt.
+func TestDeliver_429_IsRetried(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+
+	srv, pubURL := startTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := attempts.Add(1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	metrics := &mockMetrics{}
+	lister := &mockLister{
+		endpoints: []Endpoint{
+			{ID: "ep-429", URL: pubURL, Secret: "", Active: true},
+		},
+	}
+
+	d := NewDeliverer(lister,
+		WithMetrics(metrics),
+		WithMaxRetries(3),
+		WithHTTPClient(ssrfBypassClient(srv.Listener.Addr().String())),
+	)
+
+	results := d.DeliverWithResults(context.Background(), newTestEvent())
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Success, "429 should be retried and eventually succeed")
+	assert.Equal(t, 3, results[0].Attempts, "should have taken 3 attempts (429, 429, 200)")
+	assert.Equal(t, http.StatusOK, results[0].StatusCode)
+}
+
+// ---------------------------------------------------------------------------
+// Context cancellation — Deliver returns promptly when listing fails
+// ---------------------------------------------------------------------------
+
+// TestDeliver_ContextCancelledDuringRetry verifies that when the lister returns
+// an error (simulating a cancelled-context scenario), Deliver returns promptly
+// with the error instead of entering the retry loop.
+func TestDeliver_ContextCancelledDuringRetry(t *testing.T) {
+	t.Parallel()
+
+	lister := &mockLister{
+		err: fmt.Errorf("context canceled: %w", context.Canceled),
+	}
+
+	d := NewDeliverer(lister,
+		WithMaxRetries(10), // high retries — would take ages if listing succeeded
+	)
+
+	start := time.Now()
+	err := d.Deliver(context.Background(), newTestEvent())
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "Deliver should return lister error")
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, elapsed, 2*time.Second,
+		"Deliver should complete promptly when lister fails, took %s", elapsed)
+}
+
 func TestDeliver_V1Signature_EndToEnd(t *testing.T) {
 	t.Parallel()
 

--- a/commons/webhook/signature.go
+++ b/commons/webhook/signature.go
@@ -1,0 +1,129 @@
+// Copyright 2025 Lerian Studio.
+
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// SignatureVersion controls the HMAC signing format used for X-Webhook-Signature.
+type SignatureVersion int
+
+const (
+	// SignatureV0 produces legacy payload-only signatures: "sha256=<hex(HMAC(payload))>".
+	// This is the default for backward compatibility with existing consumers.
+	SignatureV0 SignatureVersion = iota
+
+	// SignatureV1 produces versioned timestamp-bound signatures:
+	// "v1,sha256=<hex(HMAC(v1:<timestamp>.<payload>))>".
+	// The timestamp is included in the HMAC input to prevent replay attacks.
+	// Receivers must verify freshness (e.g., reject timestamps older than 5 minutes).
+	SignatureV1
+)
+
+// computeHMAC returns the hex-encoded HMAC-SHA256 of payload using the given secret.
+// This is the legacy (v0) format that signs the raw payload only.
+//
+// Design note — timestamp not included in v0 signature (by intent):
+// The signature covers the raw payload only, not the X-Webhook-Timestamp value.
+// This format is maintained for backward compatibility. New deployments should
+// prefer SignatureV1 (via WithSignatureVersion) which binds the timestamp into
+// the HMAC input to enable replay protection.
+func computeHMAC(payload []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// computeHMACv1 returns a versioned signature string:
+//
+//	"v1,sha256=<hex(HMAC-SHA256("v1:<timestamp>.<payload>", secret))>"
+//
+// The version prefix "v1:" followed by the decimal timestamp and a dot separator
+// are prepended to the payload before computing the HMAC, binding the timestamp
+// to the signature. Receivers must parse the "v1," prefix, extract the timestamp
+// from the X-Webhook-Timestamp header, reconstruct the signing input, and verify
+// the HMAC before accepting the webhook.
+func computeHMACv1(payload []byte, timestamp int64, secret string) string {
+	ts := strconv.FormatInt(timestamp, 10)
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte("v1:"))
+	mac.Write([]byte(ts))
+	mac.Write([]byte("."))
+	mac.Write(payload)
+
+	return "v1,sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// VerifySignature verifies a webhook signature by auto-detecting the version
+// from the signature string format. Returns nil on valid signature, or an error
+// describing the mismatch.
+//
+// Supported formats:
+//   - "sha256=<hex>"          — v0 (payload-only)
+//   - "v1,sha256=<hex>"       — v1 (timestamp-bound)
+//
+// For v1 signatures, the timestamp parameter is required to reconstruct the
+// signing input. For v0 signatures, the timestamp is ignored.
+func VerifySignature(payload []byte, timestamp int64, secret, signature string) error {
+	switch {
+	case strings.HasPrefix(signature, "v1,"):
+		expected := computeHMACv1(payload, timestamp, secret)
+		if !hmac.Equal([]byte(signature), []byte(expected)) {
+			return errors.New("webhook: v1 signature mismatch")
+		}
+
+		return nil
+
+	case strings.HasPrefix(signature, "sha256="):
+		expected := "sha256=" + computeHMAC(payload, secret)
+		if !hmac.Equal([]byte(signature), []byte(expected)) {
+			return errors.New("webhook: v0 signature mismatch")
+		}
+
+		return nil
+
+	default:
+		return errors.New("webhook: unrecognized signature format")
+	}
+}
+
+// VerifySignatureWithFreshness verifies a v1 webhook signature and additionally
+// checks that the timestamp is within the given tolerance window from now.
+// This provides replay protection: even if an attacker captures a valid
+// payload+signature pair, it becomes invalid after the tolerance window expires.
+//
+// For v0 ("sha256=...") signatures, freshness cannot be enforced because the
+// timestamp is not covered by the HMAC. Callers receiving v0 signatures should
+// use VerifySignature and implement replay protection independently (e.g.,
+// idempotency keys or event-ID tracking).
+func VerifySignatureWithFreshness(payload []byte, timestamp int64, secret, signature string, tolerance time.Duration) error {
+	if err := VerifySignature(payload, timestamp, secret, signature); err != nil {
+		return err
+	}
+
+	// Freshness check only applies to v1 where the timestamp is signed.
+	if strings.HasPrefix(signature, "v1,") {
+		eventTime := time.Unix(timestamp, 0)
+		delta := time.Since(eventTime)
+
+		if delta < 0 {
+			delta = -delta
+		}
+
+		if delta > tolerance {
+			return fmt.Errorf("webhook: timestamp outside tolerance window (%s > %s)", delta.Truncate(time.Second), tolerance)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- harden certificate rotation, DLQ retry handling, and webhook delivery/signature helpers so nil or panic-prone edge cases fail safely instead of dropping state or obscuring diagnostics
- tighten SSRF and idempotency behavior by rejecting more unsafe inputs, honoring canceled contexts, and logging cached-response serialization failures while preserving existing fail-open behavior
- sync repository guidance and inline security notes with the updated helper contracts and known trade-offs

## Testing
- go test -tags=unit ./commons/certificate ./commons/dlq ./commons/security/ssrf ./commons/net/http/idempotency ./commons/webhook ./commons/net/http ./commons/systemplane/adapters/http/fiber