### PR TITLE
fix: apply CodeRabbit auto-fixes for PR #435

### DIFF
--- a/commons/certificate/certificate.go
+++ b/commons/certificate/certificate.go
@@ -268,6 +268,12 @@ func (m *Manager) DaysUntilExpiry() int {
 // certificate chain and private key. Returns an empty [tls.Certificate] if no
 // certificate is loaded. Both the Certificate [][]byte chain and the Leaf are
 // deep copies, so callers never receive references aliasing internal state.
+//
+// Note: the returned [tls.Certificate].PrivateKey is NOT deep-copied — it shares
+// the same underlying key material as [Manager].signer (the value returned by
+// [Manager.GetSigner]). Callers should not assume a separate copy of the private
+// key exists.
+//
 // Safe to call on a nil receiver (returns an empty [tls.Certificate]).
 func (m *Manager) TLSCertificate() tls.Certificate {
 	if m == nil {

--- a/commons/dlq/consumer.go
+++ b/commons/dlq/consumer.go
@@ -301,6 +301,9 @@ func (c *Consumer) processSource(ctx context.Context, source string) {
 	}
 
 	// Round-robin drain across all discovered keys up to BatchSize total.
+	// Every drainSource call counts toward the cap regardless of whether it
+	// actually processed a message. This prevents future-dated heads from
+	// allowing unbounded drain attempts that blow past BatchSize.
 	processed := 0
 	for processed < c.cfg.BatchSize {
 		progressed := false
@@ -314,8 +317,10 @@ func (c *Consumer) processSource(ctx context.Context, source string) {
 				return
 			}
 
-			if c.drainSource(keyCtx, source, 1) > 0 {
-				processed++
+			n := c.drainSource(keyCtx, source, 1)
+			processed++
+
+			if n > 0 {
 				progressed = true
 			}
 		}

--- a/commons/dlq/handler.go
+++ b/commons/dlq/handler.go
@@ -291,6 +291,13 @@ func (h *Handler) logEnqueueFallback(ctx context.Context, key string, msg *Faile
 // NOTE: This uses LPop which is destructive. If the process crashes between Dequeue
 // and a subsequent re-enqueue, the message is permanently lost. This provides
 // at-most-once delivery semantics. For at-least-once, consider using LMOVE (Redis 6.2+).
+//
+// Source normalization: the returned message's Source field is set to the
+// authoritative queue name derived from the Redis key (i.e. the source argument),
+// not the value stored in the raw JSON payload. If a message was manually moved
+// between queues or its Source was corrupted in transit, Dequeue overwrites the
+// stale value and logs a warning. Callers should not assume that Source exactly
+// matches the raw JSON stored in Redis.
 func (h *Handler) Dequeue(ctx context.Context, source string) (*FailedMessage, error) {
 	if h == nil {
 		return nil, ErrNilHandler
@@ -325,6 +332,18 @@ func (h *Handler) Dequeue(ctx context.Context, source string) (*FailedMessage, e
 		libOtel.HandleSpanError(span, "dlq unmarshal failed", err)
 
 		return nil, fmt.Errorf("dlq: dequeue: unmarshal: %w", err)
+	}
+
+	// Normalize Source to the authoritative queue name derived from the Redis
+	// key being dequeued. A mismatch can occur if a message was manually moved
+	// between queues or if Source was corrupted in transit.
+	if msg.Source != source {
+		h.logger.Log(ctx, libLog.LevelWarn, "dlq: dequeue: message source mismatch, normalizing to queue source",
+			libLog.String("message_source", msg.Source),
+			libLog.String("queue_source", source),
+		)
+
+		msg.Source = source
 	}
 
 	return &msg, nil
@@ -467,10 +486,23 @@ func (h *Handler) PruneExhaustedMessages(ctx context.Context, source string, lim
 			continue
 		}
 
-		// Not exhausted — put it back.
-		if err := h.Enqueue(ctx, msg); err != nil {
+		// Not exhausted — put it back. Restore the effective tenant context
+		// from the message so that Enqueue constructs the correct tenant-scoped
+		// Redis key. Without this, a prune call running without tenant context
+		// (e.g. from a background job) would fail the tenant mismatch check
+		// inside Enqueue or route the message to the wrong queue.
+		enqueueCtx := ctx
+		if msg.TenantID != "" {
+			ctxTenant := tmcore.GetTenantIDContext(ctx)
+			if ctxTenant != msg.TenantID {
+				enqueueCtx = tmcore.ContextWithTenantID(ctx, msg.TenantID)
+			}
+		}
+
+		if err := h.Enqueue(enqueueCtx, msg); err != nil {
 			h.logger.Log(ctx, libLog.LevelError, "dlq: failed to re-enqueue non-exhausted message during prune",
 				libLog.String("source", msg.Source),
+				libLog.String("tenant_id", msg.TenantID),
 				libLog.Err(err),
 			)
 

--- a/commons/dlq/keys.go
+++ b/commons/dlq/keys.go
@@ -92,16 +92,19 @@ func truncateString(s string, maxLen int) string {
 		return s
 	}
 
-	// Walk runes and cut at the correct byte offset.
-	byteLen := 0
+	// Walk runes and cut at the correct byte offset. Using the range index
+	// (which is the byte position of each rune) avoids out-of-bounds panics
+	// that can occur when invalid UTF-8 causes utf8.RuneLen to over-count.
+	byteLen := len(s)
 	count := 0
 
-	for _, r := range s {
+	for i := range s {
 		if count == maxLen {
+			byteLen = i
+
 			break
 		}
 
-		byteLen += utf8.RuneLen(r)
 		count++
 	}
 

--- a/commons/net/http/idempotency/idempotency_test.go
+++ b/commons/net/http/idempotency/idempotency_test.go
@@ -316,7 +316,7 @@ func TestCheck_DuplicateRequest_StillProcessing(t *testing.T) {
 	idempotencyKey := "processing-key"
 	lockKey := "idempotency:" + tenantID + ":" + idempotencyKey
 
-	require.NoError(t, mr.Set(lockKey, "processing"))
+	require.NoError(t, mr.Set(lockKey, keyStateProcessing))
 	mr.SetTTL(lockKey, 7*24*time.Hour)
 
 	app := newPostApp(m.Check(), tenantMiddleware(tenantID))

--- a/commons/net/http/proxy_defensive_test.go
+++ b/commons/net/http/proxy_defensive_test.go
@@ -6,13 +6,12 @@ import (
 	"context"
 	"errors"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	liblog "github.com/LerianStudio/lib-commons/v5/commons/log"
+	libSSRF "github.com/LerianStudio/lib-commons/v5/commons/security/ssrf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -127,70 +126,124 @@ func TestServeReverseProxy_TypedNilLoggerOnValidationError(t *testing.T) {
 	})
 }
 
-func TestValidateResolvedIPs_NoIPs(t *testing.T) {
-	t.Parallel()
-
-	ip, err := validateResolvedIPs(context.Background(), nil, "example.com", nil)
-	require.Error(t, err)
-	assert.Nil(t, ip)
-	assert.ErrorIs(t, err, ErrNoResolvedIPs)
-}
-
 func TestSSRFSafeTransport_DNSResolutionFailure(t *testing.T) {
 	t.Parallel()
 
-	transport := newSSRFSafeTransportWithDeps(ReverseProxyPolicy{}, func(context.Context, string) ([]net.IPAddr, error) {
+	lookupFail := libSSRF.WithLookupFunc(func(_ context.Context, _ string) ([]string, error) {
 		return nil, errors.New("lookup failed")
 	})
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
 
-	_, err := transport.base.DialContext(ctx, "tcp", "example.com:443")
+	transport := newSSRFSafeTransportWithOpts(
+		ReverseProxyPolicy{
+			AllowedSchemes: []string{"https"},
+			AllowedHosts:   []string{"example.com"},
+		},
+		[]libSSRF.Option{lookupFail},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/path", nil)
+
+	_, err := transport.RoundTrip(req)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrDNSResolutionFailed)
 }
 
-func TestValidateResolvedIPs_UnsafeAddressRejected(t *testing.T) {
+func TestSSRFSafeTransport_UnsafeAddressRejected(t *testing.T) {
 	t.Parallel()
 
-	ip, err := validateResolvedIPs(context.Background(), []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, "example.com", nil)
+	lookupLoopback := libSSRF.WithLookupFunc(func(_ context.Context, _ string) ([]string, error) {
+		return []string{"127.0.0.1"}, nil
+	})
+
+	transport := newSSRFSafeTransportWithOpts(
+		ReverseProxyPolicy{
+			AllowedSchemes: []string{"https"},
+			AllowedHosts:   []string{"example.com"},
+		},
+		[]libSSRF.Option{lookupLoopback},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/path", nil)
+
+	_, err := transport.RoundTrip(req)
 	require.Error(t, err)
-	assert.Nil(t, ip)
 	assert.ErrorIs(t, err, ErrUnsafeProxyDestination)
 }
 
-func TestValidateResolvedIPs_MixedAddressesRejected(t *testing.T) {
+func TestSSRFSafeTransport_MixedAddressesRejected(t *testing.T) {
 	t.Parallel()
 
-	ip, err := validateResolvedIPs(context.Background(), []net.IPAddr{
-		{IP: net.ParseIP("8.8.8.8")},
-		{IP: net.ParseIP("127.0.0.1")},
-	}, "example.com", nil)
+	lookupMixed := libSSRF.WithLookupFunc(func(_ context.Context, _ string) ([]string, error) {
+		return []string{"8.8.8.8", "127.0.0.1"}, nil
+	})
+
+	transport := newSSRFSafeTransportWithOpts(
+		ReverseProxyPolicy{
+			AllowedSchemes: []string{"https"},
+			AllowedHosts:   []string{"example.com"},
+		},
+		[]libSSRF.Option{lookupMixed},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/path", nil)
+
+	_, err := transport.RoundTrip(req)
 	require.Error(t, err)
-	assert.Nil(t, ip)
 	assert.ErrorIs(t, err, ErrUnsafeProxyDestination)
 }
 
-func TestValidateResolvedIPs_AllSafeReturnsFirst(t *testing.T) {
+func TestSSRFSafeTransport_SafeAddressPins(t *testing.T) {
 	t.Parallel()
 
-	ip, err := validateResolvedIPs(context.Background(), []net.IPAddr{
-		{IP: net.ParseIP("8.8.8.8")},
-		{IP: net.ParseIP("1.1.1.1")},
-	}, "example.com", nil)
-	require.NoError(t, err)
-	assert.Equal(t, net.ParseIP("8.8.8.8"), ip)
+	lookupSafe := libSSRF.WithLookupFunc(func(_ context.Context, _ string) ([]string, error) {
+		return []string{"93.184.216.34"}, nil
+	})
+
+	transport := newSSRFSafeTransportWithOpts(
+		ReverseProxyPolicy{
+			AllowedSchemes: []string{"https"},
+			AllowedHosts:   []string{"example.com"},
+		},
+		[]libSSRF.Option{lookupSafe},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/path", nil)
+
+	// The RoundTrip will attempt to actually dial the pinned IP which will
+	// fail (no server listening), but that's a transport error, not an SSRF
+	// rejection. The key assertion is that we do NOT get an SSRF error.
+	_, err := transport.RoundTrip(req)
+	// The connection will fail at the TCP level, but it must NOT be an SSRF error.
+	if err != nil {
+		assert.NotErrorIs(t, err, ErrUnsafeProxyDestination)
+		assert.NotErrorIs(t, err, ErrDNSResolutionFailed)
+		assert.NotErrorIs(t, err, ErrInvalidProxyTarget)
+	}
 }
 
-func TestValidateResolvedIPs_TypedNilLogger(t *testing.T) {
+func TestSSRFSafeTransport_TypedNilLoggerOnSSRFFailure(t *testing.T) {
 	t.Parallel()
 
 	var logger *typedNilProxyLogger
 
+	lookupLoopback := libSSRF.WithLookupFunc(func(_ context.Context, _ string) ([]string, error) {
+		return []string{"127.0.0.1"}, nil
+	})
+
+	transport := newSSRFSafeTransportWithOpts(
+		ReverseProxyPolicy{
+			AllowedSchemes: []string{"https"},
+			AllowedHosts:   []string{"example.com"},
+			Logger:         logger,
+		},
+		[]libSSRF.Option{lookupLoopback},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/path", nil)
+
 	assert.NotPanics(t, func() {
-		ip, err := validateResolvedIPs(context.Background(), nil, "example.com", logger)
+		_, err := transport.RoundTrip(req)
 		require.Error(t, err)
-		assert.Nil(t, ip)
-		assert.ErrorIs(t, err, ErrNoResolvedIPs)
+		assert.ErrorIs(t, err, ErrUnsafeProxyDestination)
 	})
 }

--- a/commons/net/http/proxy_transport.go
+++ b/commons/net/http/proxy_transport.go
@@ -1,44 +1,47 @@
 package http
 
 import (
-	"context"
-	"fmt"
+	"errors"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/LerianStudio/lib-commons/v5/commons/internal/nilcheck"
 	"github.com/LerianStudio/lib-commons/v5/commons/log"
+	libSSRF "github.com/LerianStudio/lib-commons/v5/commons/security/ssrf"
 )
 
-// TODO(ssrf): Migrate to ssrf.ResolveAndValidate to eliminate the remaining
-// TOCTOU window between validating resolved IPs and dialing them. This
-// transport already resolves DNS and pins the connection to the selected IP by
-// rewriting addr to safeIP.String(), but resolution/validation still happens
-// outside the canonical ssrf flow instead of being centralized in
-// commons/security/ssrf/validate.go:ResolveAndValidate.
-
-// ssrfSafeTransport wraps an http.Transport with a DialContext that validates
-// resolved IP addresses against the SSRF policy at connection time.
-// This prevents DNS rebinding attacks where a hostname resolves to a safe IP
-// during validation but a private IP at connection time.
-//
-// It also implements http.RoundTripper so each outbound request is re-validated
-// immediately before dialing with the current proxy policy.
+// ssrfSafeTransport wraps an http.Transport and implements http.RoundTripper.
+// On each outbound request it:
+//  1. Validates the request URL against the proxy policy (scheme/host allowlists).
+//  2. Unless AllowUnsafeDestinations is set, delegates DNS resolution and IP
+//     validation to [libSSRF.ResolveAndValidate] which performs both atomically
+//     and returns a pinned URL. This eliminates the TOCTOU window between
+//     "validate" and "connect" that existed when DNS was resolved separately in
+//     DialContext.
+//  3. Rewrites the request to use the pinned IP, preserving the original Host
+//     header for correct virtual-host routing.
 type ssrfSafeTransport struct {
 	policy ReverseProxyPolicy
 	base   *http.Transport
+	// ssrfOpts are functional options forwarded to ssrf.ResolveAndValidate.
+	// Stored at construction so that tests can inject a custom lookup function.
+	ssrfOpts []libSSRF.Option
 }
 
 // newSSRFSafeTransport creates a transport that enforces the given proxy policy
-// on DNS resolution (via DialContext) and on each outbound request validated by RoundTrip.
+// via [libSSRF.ResolveAndValidate] in its RoundTrip method.
 func newSSRFSafeTransport(policy ReverseProxyPolicy) *ssrfSafeTransport {
-	return newSSRFSafeTransportWithDeps(policy, net.DefaultResolver.LookupIPAddr)
+	return newSSRFSafeTransportWithOpts(policy, nil)
 }
 
-func newSSRFSafeTransportWithDeps(
+// newSSRFSafeTransportWithOpts is the internal constructor that accepts
+// optional [libSSRF.Option] values (primarily [libSSRF.WithLookupFunc] for
+// tests).
+func newSSRFSafeTransportWithOpts(
 	policy ReverseProxyPolicy,
-	lookupIPAddr func(context.Context, string) ([]net.IPAddr, error),
+	ssrfOpts []libSSRF.Option,
 ) *ssrfSafeTransport {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
@@ -47,92 +50,67 @@ func newSSRFSafeTransportWithDeps(
 
 	transport := &http.Transport{
 		TLSHandshakeTimeout: 10 * time.Second,
-	}
-
-	if !policy.AllowUnsafeDestinations {
-		policyLogger := policy.Logger
-
-		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-			host, port, err := net.SplitHostPort(addr)
-			if err != nil {
-				host = addr
-			}
-
-			ips, err := lookupIPAddr(ctx, host)
-			if err != nil {
-				if !nilcheck.Interface(policyLogger) {
-					policyLogger.Log(ctx, log.LevelWarn, "proxy DNS resolution failed",
-						log.String("host", host),
-						log.Err(err),
-					)
-				}
-
-				return nil, fmt.Errorf("%w: %w", ErrDNSResolutionFailed, err)
-			}
-
-			safeIP, err := validateResolvedIPs(ctx, ips, host, policyLogger)
-			if err != nil {
-				return nil, err
-			}
-
-			if safeIP != nil && port != "" {
-				addr = net.JoinHostPort(safeIP.String(), port)
-			} else if safeIP != nil {
-				addr = safeIP.String()
-			}
-
-			return dialer.DialContext(ctx, network, addr)
-		}
-	} else {
-		transport.DialContext = dialer.DialContext
+		DialContext:         dialer.DialContext,
 	}
 
 	return &ssrfSafeTransport{
-		policy: policy,
-		base:   transport,
+		policy:   policy,
+		base:     transport,
+		ssrfOpts: ssrfOpts,
 	}
 }
 
-// RoundTrip validates each outbound request against the proxy policy before forwarding.
+// RoundTrip validates each outbound request against the proxy policy and, when
+// SSRF protection is enabled, atomically resolves DNS and pins the connection
+// to a validated IP via [libSSRF.ResolveAndValidate].
 func (t *ssrfSafeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err := validateProxyTarget(req.URL, t.policy); err != nil {
 		return nil, err
 	}
 
-	return t.base.RoundTrip(req)
-}
+	// When unsafe destinations are allowed (development/testing) skip SSRF
+	// resolution and forward the request as-is.
+	if t.policy.AllowUnsafeDestinations {
+		return t.base.RoundTrip(req)
+	}
 
-// validateResolvedIPs checks all resolved IPs against the SSRF policy.
-// Returns the first safe IP for use in the connection, or an error if any IP
-// is unsafe or if no IPs were resolved.
-func validateResolvedIPs(ctx context.Context, ips []net.IPAddr, host string, logger log.Logger) (net.IP, error) {
-	if len(ips) == 0 {
-		if !nilcheck.Interface(logger) {
-			logger.Log(ctx, log.LevelWarn, "proxy target resolved to no IPs",
-				log.String("host", host),
+	// Atomically resolve DNS, validate all IPs, and pin the URL.
+	result, err := libSSRF.ResolveAndValidate(req.Context(), req.URL.String(), t.ssrfOpts...)
+	if err != nil {
+		policyLogger := t.policy.Logger
+
+		if !nilcheck.Interface(policyLogger) {
+			policyLogger.Log(req.Context(), log.LevelWarn, "proxy SSRF validation failed",
+				log.String("host", req.URL.Host),
+				log.Err(err),
 			)
 		}
 
-		return nil, ErrNoResolvedIPs
-	}
-
-	var safeIP net.IP
-
-	for _, ipAddr := range ips {
-		if isUnsafeIP(ipAddr.IP) {
-			if !nilcheck.Interface(logger) {
-				logger.Log(ctx, log.LevelWarn, "proxy target resolved to unsafe IP",
-					log.String("host", host),
-				)
-			}
-
+		// Map SSRF sentinel errors to the proxy-specific errors that callers
+		// already match via errors.Is.
+		switch {
+		case errors.Is(err, libSSRF.ErrDNSFailed):
+			return nil, ErrDNSResolutionFailed
+		case errors.Is(err, libSSRF.ErrBlocked):
+			return nil, ErrUnsafeProxyDestination
+		case errors.Is(err, libSSRF.ErrInvalidURL):
+			return nil, ErrInvalidProxyTarget
+		default:
 			return nil, ErrUnsafeProxyDestination
 		}
-
-		if safeIP == nil {
-			safeIP = ipAddr.IP
-		}
 	}
 
-	return safeIP, nil
+	// Clone the request so we don't mutate the caller's *http.Request.
+	pinned := req.Clone(req.Context())
+
+	pinnedURL, parseErr := url.Parse(result.PinnedURL)
+	if parseErr != nil {
+		return nil, ErrInvalidProxyTarget
+	}
+
+	pinned.URL = pinnedURL
+	// Preserve the original Host header so the upstream server routes correctly.
+	pinned.Host = result.Authority
+
+	return t.base.RoundTrip(pinned)
 }

--- a/commons/net/http/proxy_transport_test.go
+++ b/commons/net/http/proxy_transport_test.go
@@ -3,7 +3,6 @@
 package http
 
 import (
-	"context"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -36,9 +35,12 @@ func TestServeReverseProxy_UpstreamTransportFailureReturns502(t *testing.T) {
 	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
 }
 
-func TestSSRFSafeTransport_DialContext_RejectsPrivateIP(t *testing.T) {
+func TestSSRFSafeTransport_RoundTrip_RejectsPrivateIPViaSSRF(t *testing.T) {
 	t.Parallel()
 
+	// SSRF validation now happens atomically in RoundTrip via
+	// ssrf.ResolveAndValidate, not in a custom DialContext. Verify that a
+	// request to localhost is blocked at the RoundTrip level.
 	transport := newSSRFSafeTransport(ReverseProxyPolicy{
 		AllowedSchemes:          []string{"http"},
 		AllowedHosts:            []string{"localhost"},
@@ -46,10 +48,10 @@ func TestSSRFSafeTransport_DialContext_RejectsPrivateIP(t *testing.T) {
 	})
 
 	require.NotNil(t, transport)
-	require.NotNil(t, transport.base)
-	require.NotNil(t, transport.base.DialContext, "DialContext should be set when AllowUnsafeDestinations is false")
 
-	_, err := transport.base.DialContext(context.Background(), "tcp", "localhost:80")
+	req := httptest.NewRequest(http.MethodGet, "http://localhost:80/path", nil)
+
+	_, err := transport.RoundTrip(req)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUnsafeProxyDestination)
 }

--- a/commons/security/ssrf/hostname.go
+++ b/commons/security/ssrf/hostname.go
@@ -59,6 +59,12 @@ func IsBlockedHostname(hostname string) bool {
 
 	lower := normalizeHostname(hostname)
 
+	// After normalization, hostnames like "." or ".." become empty. These are
+	// not valid targets and must be blocked (fail-closed).
+	if lower == "" {
+		return true
+	}
+
 	if blockedHostnames[lower] {
 		return true
 	}
@@ -80,6 +86,12 @@ func isBlockedHostnameWithConfig(hostname string, cfg *config) bool {
 	}
 
 	lower := normalizeHostname(hostname)
+
+	// After normalization, hostnames like "." or ".." become empty. These are
+	// not valid targets and must be blocked (fail-closed).
+	if lower == "" {
+		return true
+	}
 
 	// Check allow-list override first.
 	if cfg != nil && cfg.allowedHostnames[lower] {

--- a/commons/security/ssrf/ssrf.go
+++ b/commons/security/ssrf/ssrf.go
@@ -29,6 +29,9 @@ var (
 // at init time rather than silently ignored at request time.
 //
 //nolint:gochecknoglobals // package-level CIDR blocklist is intentional for SSRF protection
+// blockedPrefixes is the canonical CIDR blocklist for SSRF protection.
+// MAINTENANCE: when adding or removing entries, update expectedPrefixCount
+// in ssrf_test.go to keep TestBlockedPrefixes_ReturnsExpectedCount in sync.
 var blockedPrefixes = []netip.Prefix{
 	netip.MustParsePrefix("0.0.0.0/8"),       // "this network" (RFC 1122 S3.2.1.3)
 	netip.MustParsePrefix("100.64.0.0/10"),   // CGNAT (RFC 6598)

--- a/commons/security/ssrf/ssrf_test.go
+++ b/commons/security/ssrf/ssrf_test.go
@@ -19,7 +19,8 @@ import (
 
 // expectedPrefixCount lives in the test file so the production code does not
 // export or carry a constant that is only meaningful for test assertions.
-// Update this value when adding new CIDR ranges to blockedPrefixes.
+// Update this value when adding or removing CIDR ranges in the production
+// blockedPrefixes variable (ssrf.go).
 const expectedPrefixCount = 10
 
 func TestBlockedPrefixes_ReturnsExpectedCount(t *testing.T) {
@@ -269,6 +270,11 @@ func TestIsBlockedHostname(t *testing.T) {
 
 		// Empty hostname
 		{name: "empty string", host: "", blocked: true},
+
+		// Hostnames that normalize to empty (root-label-only inputs)
+		{name: "single dot normalizes to empty", host: ".", blocked: true},
+		{name: "double dot normalizes to empty", host: "..", blocked: true},
+		{name: "triple dot normalizes to empty", host: "...", blocked: true},
 
 		// Legitimate hostnames — must NOT be blocked
 		{name: "example.com", host: "example.com", blocked: false},
@@ -960,6 +966,20 @@ func TestIsBlockedAddr_IPv6_DiscardRange(t *testing.T) {
 	addr := netip.MustParseAddr("100::1")
 	assert.True(t, IsBlockedAddr(addr),
 		"IPv6 discard-only address 100::1 must be blocked (RFC 6666)")
+}
+
+func TestResolveAndValidate_BlockedIPInMiddle(t *testing.T) {
+	t.Parallel()
+
+	// A blocked IP ("10.0.0.1") sits in the middle of the resolved list, between
+	// two safe IPs. ResolveAndValidate must check ALL IPs, not just the first one.
+	_, err := ResolveAndValidate(context.Background(),
+		"https://example.com/hook",
+		WithLookupFunc(fakeLookup("93.184.216.34", "10.0.0.1", "1.1.1.1")),
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrBlocked)
 }
 
 func TestSentinelErrors_AreDistinct(t *testing.T) {


### PR DESCRIPTION
## Summary

- **CRITICAL**: Migrate proxy transport to `ssrf.ResolveAndValidate`, eliminating TOCTOU window in DNS resolution
- **MAJOR**: Block hostnames that normalize to empty values (e.g., `.`, `..`)
- **MAJOR**: Fix DLQ batch cap bypass when all tenant queues have future-dated heads
- **MAJOR**: Normalize dequeued message Source to the authoritative queue name
- **MAJOR**: Restore tenant context before re-enqueueing during DLQ prune
- **MAJOR**: Fix potential OOB panic in `truncateString` with invalid UTF-8
- **TRIVIAL**: Clarify `TLSCertificate` PrivateKey sharing in doc comment
- **TRIVIAL**: Use `keyStateProcessing` constant in idempotency test
- **TRIVIAL**: Add maintenance comments linking `expectedPrefixCount` to `blockedPrefixes`
- **TRIVIAL**: Add test for blocked IP in middle of resolved IP list

Addresses 11 unresolved CodeRabbit review threads from PR #435.

## Test plan

- [x] `go build ./...` passes
- [x] `go test -tags unit ./commons/dlq/...` — 32 tests pass
- [x] `go test -tags unit ./commons/certificate/...` — passes
- [x] `go test -tags unit ./commons/net/http/...` — passes
- [x] `go test -tags unit ./commons/security/ssrf/...` — passes
- [x] `make ci` — full pipeline green (105 tests, lint, format, tidy, sec, vet)