### PR TITLE
fix: copy Fiber context strings before c.Next() to prevent UnsafeString race

### DIFF
--- a/commons/net/http/withTelemetry.go
+++ b/commons/net/http/withTelemetry.go
@@ -60,14 +60,25 @@ func (tm *TelemetryMiddleware) WithTelemetry(tl *opentelemetry.Telemetry, exclud
 			return c.Next()
 		}
 
+		// Capture all Fiber context string values BEFORE c.Next(). Fiber v2 uses
+		// utils.UnsafeString which returns pointers into fasthttp's request buffer.
+		// After c.Next() returns, fasthttp may recycle the underlying RequestCtx
+		// for the next connection, corrupting any previously returned string slices.
+		// Safe copies via string([]byte(...)) ensure the data is heap-owned.
+		method := string([]byte(c.Method()))
+		originalURL := string([]byte(c.OriginalURL()))
+		protocol := string([]byte(c.Protocol()))
+		hostname := string([]byte(c.Hostname()))
+		userAgent := string([]byte(c.Get(cn.HeaderUserAgent)))
+
 		tracer := effectiveTelemetry.TracerProvider.Tracer(effectiveTelemetry.LibraryName)
-		routePathWithMethod := c.Method() + " " + commons.ReplaceUUIDWithPlaceholder(c.Path())
+		routePathWithMethod := method + " " + commons.ReplaceUUIDWithPlaceholder(c.Path())
 
 		traceCtx := c.UserContext()
 		// Compatibility note: trace extraction currently trusts the internal-service
 		// User-Agent heuristic. This is an interoperability hint, not an authenticated
 		// trust boundary, and is preserved to avoid changing existing caller behavior.
-		if commons.IsInternalLerianService(c.Get(cn.HeaderUserAgent)) {
+		if commons.IsInternalLerianService(userAgent) {
 			traceCtx = opentelemetry.ExtractHTTPContext(traceCtx, c)
 		}
 
@@ -87,12 +98,12 @@ func (tm *TelemetryMiddleware) WithTelemetry(tl *opentelemetry.Telemetry, exclud
 
 		statusCode := c.Response().StatusCode()
 		span.SetAttributes(
-			attribute.String("http.request.method", c.Method()),
-			attribute.String("url.path", sanitizeURL(c.OriginalURL())),
+			attribute.String("http.request.method", method),
+			attribute.String("url.path", sanitizeURL(originalURL)),
 			attribute.String("http.route", c.Route().Path),
-			attribute.String("url.scheme", c.Protocol()),
-			attribute.String("server.address", c.Hostname()),
-			attribute.String("user_agent.original", c.Get(cn.HeaderUserAgent)),
+			attribute.String("url.scheme", protocol),
+			attribute.String("server.address", hostname),
+			attribute.String("user_agent.original", userAgent),
 			attribute.Int("http.response.status_code", statusCode),
 		)
 


### PR DESCRIPTION
## Problem

The `WithTelemetry` middleware in `commons/net/http/withTelemetry.go` reads Fiber context values (`c.Method()`, `c.OriginalURL()`, `c.Protocol()`, `c.Hostname()`, `c.Get(HeaderUserAgent)`) **after** `c.Next()` when setting span attributes.

Fiber v2 uses `utils.UnsafeString` which returns Go strings backed by fasthttp's `RequestCtx` buffer memory. After `c.Next()` returns, fasthttp may recycle the buffer for the next request, causing data corruption:
- `GET` → `GETT`, `GETC`, `GETCH`, `GETD`, `GETTH`
- `POST` → `POS`, `POSTH`

Each corrupted label creates a new metric series in the OTEL spanmetrics connector, inflating `calls_total` (observed: 122 series for Voluti vs ~35 for other clients, with a 1500:1 ratio vs Loki).

## Fix

Capture all five Fiber context string values into heap-owned local variables **before** `c.Next()` using `string([]byte(...))` to force a safe copy off the fasthttp buffer. Use those locals in `span.SetAttributes` after `c.Next()`.

`c.Route().Path` (struct field) and `c.Response().StatusCode()` (int) are safe and left as-is.

## Ref

- Thread: #devops-team — Voluti calls_total inflation investigation
- Root cause analysis by @gauchito91 (label corruption) + @ferr3ira-gabriel (span_kind context)

Requested by: @qnen