### PR TITLE
docs: deprecate commons observability APIs

### DIFF
--- a/commons/context.go
+++ b/commons/context.go
@@ -42,6 +42,8 @@ type CustomContextKeyValue struct {
 // NewLoggerFromContext extract the Logger from "logger" value inside context.
 // A nil ctx is normalized to context.Background() so callers never trigger a nil-pointer dereference.
 //
+// Deprecated: use NewLoggerFromContext from github.com/LerianStudio/lib-observability.
+//
 //nolint:ireturn
 func NewLoggerFromContext(ctx context.Context) log.Logger {
 	if ctx == nil {
@@ -78,6 +80,8 @@ func cloneContextValues(ctx context.Context) *CustomContextKeyValue {
 }
 
 // ContextWithLogger returns a context within a Logger in "logger" value.
+//
+// Deprecated: use ContextWithLogger from github.com/LerianStudio/lib-observability.
 func ContextWithLogger(ctx context.Context, logger log.Logger) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
@@ -92,6 +96,8 @@ func ContextWithLogger(ctx context.Context, logger log.Logger) context.Context {
 // ---- Tracer helpers ----
 
 // ContextWithTracer returns a context within a trace.Tracer in "tracer" value.
+//
+// Deprecated: use ContextWithTracer from github.com/LerianStudio/lib-observability.
 func ContextWithTracer(ctx context.Context, tracer trace.Tracer) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
@@ -106,6 +112,8 @@ func ContextWithTracer(ctx context.Context, tracer trace.Tracer) context.Context
 // ---- Metrics helpers ----
 
 // ContextWithMetricFactory returns a context within a MetricsFactory in "metricFactory" value.
+//
+// Deprecated: use ContextWithMetricFactory from github.com/LerianStudio/lib-observability.
 func ContextWithMetricFactory(ctx context.Context, metricFactory *metrics.MetricsFactory) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
@@ -120,6 +128,8 @@ func ContextWithMetricFactory(ctx context.Context, metricFactory *metrics.Metric
 // ---- Correlation / HeaderID helpers ----
 
 // ContextWithHeaderID returns a context within a HeaderID in "headerID" value.
+//
+// Deprecated: use ContextWithHeaderID from github.com/LerianStudio/lib-observability.
 func ContextWithHeaderID(ctx context.Context, headerID string) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
@@ -135,6 +145,8 @@ func ContextWithHeaderID(ctx context.Context, headerID string) context.Context {
 
 // TrackingComponents represents the complete set of tracking components extracted from context.
 // This struct encapsulates all telemetry-related dependencies in a single, cohesive unit.
+//
+// Deprecated: use TrackingComponents from github.com/LerianStudio/lib-observability.
 type TrackingComponents struct {
 	Logger        log.Logger
 	Tracer        trace.Tracer
@@ -144,6 +156,8 @@ type TrackingComponents struct {
 
 // NewTrackingFromContext extracts tracking components from context with intelligent fallback.
 // It follows the fail-safe principle: preserve valid components, provide sensible defaults for invalid ones.
+//
+// Deprecated: use NewTrackingFromContext from github.com/LerianStudio/lib-observability.
 //
 //nolint:ireturn
 func NewTrackingFromContext(ctx context.Context) (log.Logger, trace.Tracer, string, *metrics.MetricsFactory) {
@@ -254,6 +268,8 @@ func newDefaultTrackingComponents() TrackingComponents {
 // ContextWithSpanAttributes appends one or more attributes to the request's AttrBag.
 // Call this once at the ingress (HTTP/gRPC middleware) and avoid per-layer duplication.
 // Example keys: tenant.id, enduser.id, request.route, region, plan.
+//
+// Deprecated: use ContextWithSpanAttributes from github.com/LerianStudio/lib-observability.
 func ContextWithSpanAttributes(ctx context.Context, kv ...attribute.KeyValue) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
@@ -271,6 +287,8 @@ func ContextWithSpanAttributes(ctx context.Context, kv ...attribute.KeyValue) co
 }
 
 // AttributesFromContext returns a shallow copy of the AttrBag slice, safe to reuse by processors.
+//
+// Deprecated: use AttributesFromContext from github.com/LerianStudio/lib-observability.
 func AttributesFromContext(ctx context.Context) []attribute.KeyValue {
 	if ctx == nil {
 		return nil
@@ -287,6 +305,8 @@ func AttributesFromContext(ctx context.Context) []attribute.KeyValue {
 }
 
 // ReplaceAttributes resets the current AttrBag with a new set (rarely needed; provided for completeness).
+//
+// Deprecated: use ReplaceAttributes from github.com/LerianStudio/lib-observability.
 func ReplaceAttributes(ctx context.Context, kv ...attribute.KeyValue) context.Context {
 	if ctx == nil {
 		ctx = context.Background()

--- a/commons/net/http/context_span.go
+++ b/commons/net/http/context_span.go
@@ -15,6 +15,8 @@ func isNilSpan(span trace.Span) bool {
 }
 
 // SetHandlerSpanAttributes adds tenant_id and context_id attributes to a trace span.
+//
+// Deprecated: use SetHandlerSpanAttributes from github.com/LerianStudio/lib-observability/middleware.
 func SetHandlerSpanAttributes(span trace.Span, tenantID, contextID uuid.UUID) {
 	if isNilSpan(span) {
 		return
@@ -28,6 +30,8 @@ func SetHandlerSpanAttributes(span trace.Span, tenantID, contextID uuid.UUID) {
 }
 
 // SetTenantSpanAttribute adds tenant_id attribute to a trace span.
+//
+// Deprecated: use SetTenantSpanAttribute from github.com/LerianStudio/lib-observability/middleware.
 func SetTenantSpanAttribute(span trace.Span, tenantID uuid.UUID) {
 	if isNilSpan(span) {
 		return
@@ -37,6 +41,8 @@ func SetTenantSpanAttribute(span trace.Span, tenantID uuid.UUID) {
 }
 
 // SetExceptionSpanAttributes adds tenant_id and exception_id attributes to a trace span.
+//
+// Deprecated: use SetExceptionSpanAttributes from github.com/LerianStudio/lib-observability/middleware.
 func SetExceptionSpanAttributes(span trace.Span, tenantID, exceptionID uuid.UUID) {
 	if isNilSpan(span) {
 		return
@@ -47,6 +53,8 @@ func SetExceptionSpanAttributes(span trace.Span, tenantID, exceptionID uuid.UUID
 }
 
 // SetDisputeSpanAttributes adds tenant_id and dispute_id attributes to a trace span.
+//
+// Deprecated: use SetDisputeSpanAttributes from github.com/LerianStudio/lib-observability/middleware.
 func SetDisputeSpanAttributes(span trace.Span, tenantID, disputeID uuid.UUID) {
 	if isNilSpan(span) {
 		return

--- a/commons/net/http/withLogging.go
+++ b/commons/net/http/withLogging.go
@@ -28,6 +28,8 @@ func init() {
 }
 
 // RequestInfo is a struct design to store http access log data.
+//
+// Deprecated: use RequestInfo from github.com/LerianStudio/lib-observability/middleware.
 type RequestInfo struct {
 	Method        string
 	Username      string
@@ -45,6 +47,8 @@ type RequestInfo struct {
 }
 
 // ResponseMetricsWrapper is a Wrapper responsible for collecting the response data such as status code and size.
+//
+// Deprecated: use ResponseMetricsWrapper from github.com/LerianStudio/lib-observability/middleware.
 type ResponseMetricsWrapper struct {
 	Context    *fiber.Ctx
 	StatusCode int
@@ -56,6 +60,8 @@ type ResponseMetricsWrapper struct {
 // request body are obfuscated. Pass the middleware's effective setting (which
 // combines the global LOG_OBFUSCATION_DISABLED env var with per-middleware
 // overrides via WithObfuscationDisabled) to honour per-middleware configuration.
+//
+// Deprecated: use NewRequestInfo from github.com/LerianStudio/lib-observability/middleware.
 func NewRequestInfo(c *fiber.Ctx, obfuscationDisabled bool) *RequestInfo {
 	if c == nil {
 		return &RequestInfo{Date: time.Now().UTC()}
@@ -102,6 +108,8 @@ func NewRequestInfo(c *fiber.Ctx, obfuscationDisabled bool) *RequestInfo {
 
 // CLFString produces a log entry format similar to Common Log Format (CLF)
 // Ref: https://httpd.apache.org/docs/trunk/logs.html#common
+//
+// Deprecated: use RequestInfo.CLFString from github.com/LerianStudio/lib-observability/middleware.
 func (r *RequestInfo) CLFString() string {
 	return strings.Join([]string{
 		sanitizeLogValue(r.RemoteAddress),
@@ -118,12 +126,16 @@ func (r *RequestInfo) CLFString() string {
 }
 
 // String implements fmt.Stringer interface and produces a log entry using RequestInfo.CLFExtendedString.
+//
+// Deprecated: use RequestInfo.String from github.com/LerianStudio/lib-observability/middleware.
 func (r *RequestInfo) String() string {
 	return r.CLFString()
 }
 
 // FinishRequestInfo calculates the duration of RequestInfo automatically using time.Now()
 // It also set StatusCode and Size of RequestInfo passed by ResponseMetricsWrapper.
+//
+// Deprecated: use RequestInfo.FinishRequestInfo from github.com/LerianStudio/lib-observability/middleware.
 func (r *RequestInfo) FinishRequestInfo(rw *ResponseMetricsWrapper) {
 	if rw == nil {
 		return

--- a/commons/net/http/withLogging_middleware.go
+++ b/commons/net/http/withLogging_middleware.go
@@ -23,9 +23,13 @@ type logMiddleware struct {
 }
 
 // LogMiddlewareOption represents the log middleware function as an implementation.
+//
+// Deprecated: use LogMiddlewareOption from github.com/LerianStudio/lib-observability/middleware.
 type LogMiddlewareOption func(l *logMiddleware)
 
 // WithCustomLogger is a functional option for logMiddleware.
+//
+// Deprecated: use WithCustomLogger from github.com/LerianStudio/lib-observability/middleware.
 func WithCustomLogger(logger log.Logger) LogMiddlewareOption {
 	return func(l *logMiddleware) {
 		if !nilcheck.Interface(logger) {
@@ -37,6 +41,8 @@ func WithCustomLogger(logger log.Logger) LogMiddlewareOption {
 // WithObfuscationDisabled is a functional option that disables log body obfuscation.
 // This is primarily intended for testing and local development.
 // In production, use the LOG_OBFUSCATION_DISABLED environment variable.
+//
+// Deprecated: use WithObfuscationDisabled from github.com/LerianStudio/lib-observability/middleware.
 func WithObfuscationDisabled(disabled bool) LogMiddlewareOption {
 	return func(l *logMiddleware) {
 		l.ObfuscationDisabled = disabled
@@ -60,6 +66,8 @@ func buildOpts(opts ...LogMiddlewareOption) *logMiddleware {
 // WithHTTPLogging is a middleware to log access to http server.
 // It logs access log according to Apache Standard Logs which uses Common Log Format (CLF)
 // Ref: https://httpd.apache.org/docs/trunk/logs.html#common
+//
+// Deprecated: use WithHTTPLogging from github.com/LerianStudio/lib-observability/middleware.
 func WithHTTPLogging(opts ...LogMiddlewareOption) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		if c.Path() == "/health" {
@@ -99,6 +107,8 @@ func WithHTTPLogging(opts ...LogMiddlewareOption) fiber.Handler {
 }
 
 // WithGrpcLogging is a gRPC unary interceptor to log access to gRPC server.
+//
+// Deprecated: use WithGrpcLogging from github.com/LerianStudio/lib-observability/middleware.
 func WithGrpcLogging(opts ...LogMiddlewareOption) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,

--- a/commons/net/http/withTelemetry.go
+++ b/commons/net/http/withTelemetry.go
@@ -19,19 +19,27 @@ import (
 
 // DefaultMetricsCollectionInterval is the default interval for collecting system metrics.
 // Can be overridden via METRICS_COLLECTION_INTERVAL environment variable.
+//
+// Deprecated: use DefaultMetricsCollectionInterval from github.com/LerianStudio/lib-observability/middleware.
 const DefaultMetricsCollectionInterval = 5 * time.Second
 
 // TelemetryMiddleware wraps HTTP and gRPC handlers with tracing and metrics setup.
+//
+// Deprecated: use TelemetryMiddleware from github.com/LerianStudio/lib-observability/middleware.
 type TelemetryMiddleware struct {
 	Telemetry *opentelemetry.Telemetry
 }
 
 // NewTelemetryMiddleware creates a new instance of TelemetryMiddleware.
+//
+// Deprecated: use NewTelemetryMiddleware from github.com/LerianStudio/lib-observability/middleware.
 func NewTelemetryMiddleware(tl *opentelemetry.Telemetry) *TelemetryMiddleware {
 	return &TelemetryMiddleware{tl}
 }
 
 // WithTelemetry is a middleware that adds tracing to the context.
+//
+// Deprecated: use TelemetryMiddleware.WithTelemetry from github.com/LerianStudio/lib-observability/middleware.
 func (tm *TelemetryMiddleware) WithTelemetry(tl *opentelemetry.Telemetry, excludedRoutes ...string) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		effectiveTelemetry := tl
@@ -118,6 +126,8 @@ func (tm *TelemetryMiddleware) WithTelemetry(tl *opentelemetry.Telemetry, exclud
 }
 
 // EndTracingSpans is a middleware that ends the tracing spans.
+//
+// Deprecated: use TelemetryMiddleware.EndTracingSpans from github.com/LerianStudio/lib-observability/middleware.
 func (tm *TelemetryMiddleware) EndTracingSpans(c *fiber.Ctx) error {
 	if c == nil {
 		return ErrContextNotFound
@@ -139,6 +149,8 @@ func (tm *TelemetryMiddleware) EndTracingSpans(c *fiber.Ctx) error {
 }
 
 // WithTelemetryInterceptor is a gRPC interceptor that adds tracing to the context.
+//
+// Deprecated: use TelemetryMiddleware.WithTelemetryInterceptor from github.com/LerianStudio/lib-observability/middleware.
 func (tm *TelemetryMiddleware) WithTelemetryInterceptor(tl *opentelemetry.Telemetry) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
@@ -213,6 +225,8 @@ func (tm *TelemetryMiddleware) WithTelemetryInterceptor(tl *opentelemetry.Teleme
 }
 
 // EndTracingSpansInterceptor is a gRPC interceptor that ends the tracing spans.
+//
+// Deprecated: use TelemetryMiddleware.EndTracingSpansInterceptor from github.com/LerianStudio/lib-observability/middleware.
 func (tm *TelemetryMiddleware) EndTracingSpansInterceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,

--- a/commons/net/http/withTelemetry_metrics.go
+++ b/commons/net/http/withTelemetry_metrics.go
@@ -117,6 +117,8 @@ func (tm *TelemetryMiddleware) ensureMetricsCollector() error {
 // to allow the collector to be restarted after being stopped. This is an unusual but
 // intentional pattern - the mutex ensures thread-safety during the reset operation,
 // preventing race conditions between Stop and subsequent Start calls.
+//
+// Deprecated: use StopMetricsCollector from github.com/LerianStudio/lib-observability/middleware.
 func StopMetricsCollector() {
 	metricsCollectorMu.Lock()
 	defer metricsCollectorMu.Unlock()

--- a/commons/opentelemetry/doc.go
+++ b/commons/opentelemetry/doc.go
@@ -5,4 +5,6 @@
 //
 // The package also includes carrier utilities for HTTP, gRPC, and queue headers, plus
 // redaction-aware attribute extraction for safe span enrichment.
+//
+// Deprecated: use github.com/LerianStudio/lib-observability/tracing.
 package opentelemetry


### PR DESCRIPTION
## Summary
- marks lib-commons HTTP/gRPC logging middleware APIs as deprecated
- marks lib-commons HTTP/gRPC telemetry middleware APIs as deprecated
- marks lib-commons observability context helpers and HTTP span helpers as deprecated
- marks root commons/opentelemetry as deprecated and points it to lib-observability/tracing
- points each deprecated API to the equivalent package in lib-observability
- keeps implementation untouched so existing consumers remain compatible while Ring can detect the migration source of truth

## Validation
- go test ./commons/opentelemetry
- go test ./commons ./commons/net/http

Requested by: @qnen