### PR TITLE
fix(outbox/postgres): apply parser-safe migration hotfix to develop

### DIFF
--- a/commons/outbox/postgres/migrations/000001_outbox_events_schema.up.sql
+++ b/commons/outbox/postgres/migrations/000001_outbox_events_schema.up.sql
@@ -1,18 +1,11 @@
 -- Schema-per-tenant outbox_events table template.
 -- Apply this migration inside each tenant schema.
 
-DO $$
-BEGIN
-    IF NOT EXISTS (
-        SELECT 1
-        FROM pg_type t
-        INNER JOIN pg_namespace n ON n.oid = t.typnamespace
-        WHERE t.typname = 'outbox_event_status'
-          AND n.nspname = current_schema()
-    ) THEN
-        CREATE TYPE outbox_event_status AS ENUM ('PENDING', 'PROCESSING', 'PUBLISHED', 'FAILED', 'INVALID');
-    END IF;
-END $$;
+DO $enum$ BEGIN
+    CREATE TYPE outbox_event_status AS ENUM ('PENDING', 'PROCESSING', 'PUBLISHED', 'FAILED', 'INVALID');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $enum$;
 
 CREATE TABLE IF NOT EXISTS outbox_events (
     id UUID PRIMARY KEY,


### PR DESCRIPTION
## Summary
- applies the main hotfix for the schema-per-tenant outbox migration to develop
- unblocks the develop -> main PR by bringing PR #468 into develop

## Validation
- go test -mod=mod -tags=unit ./commons/outbox/postgres

Requested by: @qnen