### PR TITLE
chore(lint): allow release compatibility deprecations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -157,7 +157,7 @@ linters:
       - linters:
           - staticcheck
         path: ^commons/certificate/certificate\.go$
-        text: 'SA1019: k\.(X|Y) has been deprecated since Go 1\.26'
+        text: 'SA1019: .*\.(X|Y) has been deprecated since Go 1\.26'
       - linters:
           - modernize
         path: ^commons/os\.go$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -152,7 +152,7 @@ linters:
         text: 'ST1000: at least one file in a package should have a package comment'
       - linters:
           - staticcheck
-        path: ^commons/(dlq|mongo|net/http|opentelemetry|outbox|postgres|rabbitmq|redis|server|streaming|systemplane|tenant-manager|webhook|zap)(/|$)
+        path: ^commons/(assert|circuitbreaker|crypto|dlq|errgroup|license|log|mongo|net|opentelemetry|outbox|postgres|rabbitmq|redis|runtime|server|streaming|systemplane|tenant-manager|webhook|zap)(/|$)
         text: 'SA1019: .*lib-observability'
       - linters:
           - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -151,6 +151,22 @@ linters:
           - staticcheck
         text: 'ST1000: at least one file in a package should have a package comment'
       - linters:
+          - staticcheck
+        path: ^commons/
+        text: 'SA1019: .*lib-observability'
+      - linters:
+          - staticcheck
+        path: ^commons/certificate/certificate\.go$
+        text: 'SA1019: k\.(X|Y) has been deprecated since Go 1\.26'
+      - linters:
+          - modernize
+        path: ^commons/os\.go$
+        text: 'stditerators: NumField/Field loop can simplified using Type\.Fields iteration'
+      - linters:
+          - modernize
+        path: ^commons/pointers/pointers\.go$
+        text: 'newexpr: .* can be an inlinable wrapper around new\(expr\)'
+      - linters:
           - govet
         text: '^shadow: declaration of "(err|ok)" shadows declaration'
       - path: (.+)\.go$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -152,7 +152,7 @@ linters:
         text: 'ST1000: at least one file in a package should have a package comment'
       - linters:
           - staticcheck
-        path: ^commons/
+        path: ^commons/(dlq|mongo|net/http|opentelemetry|outbox|postgres|rabbitmq|redis|server|streaming|systemplane|tenant-manager|webhook|zap)(/|$)
         text: 'SA1019: .*lib-observability'
       - linters:
           - staticcheck
@@ -161,11 +161,11 @@ linters:
       - linters:
           - modernize
         path: ^commons/os\.go$
-        text: 'stditerators: NumField/Field loop can simplified using Type\.Fields iteration'
+        text: '^stditerators:'
       - linters:
           - modernize
         path: ^commons/pointers/pointers\.go$
-        text: 'newexpr: .* can be an inlinable wrapper around new\(expr\)'
+        text: '^newexpr:'
       - linters:
           - govet
         text: '^shadow: declaration of "(err|ok)" shadows declaration'


### PR DESCRIPTION
## Summary
- keeps the observability deprecation markers active for consumers
- excludes lib-commons internal compatibility usage from SA1019 so the develop -> main release PR can pass lint
- excludes Go 1.26-only modernization findings that are outside the release scope

## Validation
- inspected failing PR #471 lint output
- scoped exclusions to the reported release blockers

Requested by: @qnen