### PR TITLE
test: clarify PR 471 review assertions

### DIFF
--- a/commons/app_extra_test.go
+++ b/commons/app_extra_test.go
@@ -41,15 +41,13 @@ func TestRun_WithError_WithLogger(t *testing.T) {
 	})
 }
 
-// TestRun_LogsError covers the path where error occurs and logger is nil.
-func TestRun_LogsError(t *testing.T) {
+// TestRunWithError_NilLoggerReturnsErrLoggerNil covers the nil logger guard.
+func TestRunWithError_NilLoggerReturnsErrLoggerNil(t *testing.T) {
 	t.Parallel()
 
-	// Use a launcher with nil logger to test error logging path
-	l := &Launcher{} // no logger set - RunWithError will return ErrLoggerNil
+	l := &Launcher{}
 
-	// This will return ErrLoggerNil from RunWithError
-	// Run() then tries to log the error but l.Logger is nil so it skips
+	assert.ErrorIs(t, l.RunWithError(), ErrLoggerNil)
 	assert.NotPanics(t, func() {
 		l.Run()
 	})

--- a/commons/tenant-manager/middleware/coverage_boost_test.go
+++ b/commons/tenant-manager/middleware/coverage_boost_test.go
@@ -141,10 +141,10 @@ func TestWithTenantDB_NoTenantIDClaim_Returns401(t *testing.T) {
 }
 
 // -------------------------------------------------------------------
-// WithTenantDB — valid JWT but GetConnection fails → 503
+// WithTenantDB — valid JWT but GetConnection fails → 500
 // -------------------------------------------------------------------
 
-func TestWithTenantDB_PGGetConnectionFails_Returns503(t *testing.T) {
+func TestWithTenantDB_PGGetConnectionFails_Returns500(t *testing.T) {
 	t.Parallel()
 
 	// Tenant manager server returns 500 → GetConnection fails
@@ -299,10 +299,10 @@ func TestWithTenantDB_IsDisabled_WhenNothingConfigured(t *testing.T) {
 }
 
 // -------------------------------------------------------------------
-// mapDomainErrorToHTTP — ErrTenantNotProvisioned → 503
+// mapDomainErrorToHTTP — ErrTenantNotProvisioned → 500
 // -------------------------------------------------------------------
 
-func TestMapDomainErrorToHTTP_TenantNotProvisioned(t *testing.T) {
+func TestMapDomainErrorToHTTP_TenantNotProvisioned_Returns500(t *testing.T) {
 	t.Parallel()
 
 	app := newFiberTestApp(func(c *fiber.Ctx) error {


### PR DESCRIPTION
## Summary
- assert the nil logger launcher error directly in the app test
- align tenant middleware test names/comments with the current 500 behavior

## Validation
- go test -mod=mod -tags=unit ./commons ./commons/tenant-manager/middleware

Requested by: @qnen