### PR TITLE
fix(secretsmanager): add external credentials path builder and reader

### DIFF
--- a/commons/secretsmanager/external.go
+++ b/commons/secretsmanager/external.go
@@ -1,0 +1,186 @@
+// Copyright Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package secretsmanager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+)
+
+// # External Credentials
+//
+// External credentials are arbitrary key/value secrets stored in AWS Secrets Manager
+// for third-party integrations (Stripe, Twilio, Salesforce, webhooks, etc.).
+//
+// They live alongside M2M credentials under the same tenant/application path
+// convention but use the `external` segment instead of `m2m`:
+//
+//	tenants/{env}/{tenantOrgID}/{applicationName}/external/{targetService}/credentials
+//
+// Unlike M2M credentials — which are strictly OAuth2 clientId/clientSecret pairs —
+// external credentials hold a free-form map[string]string because every third-party
+// integration ships a different shape (api_key, webhook_secret, access_token, etc.).
+// Callers are responsible for extracting the keys they need.
+//
+// # Usage
+//
+//	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+//	if err != nil {
+//	    // handle error
+//	}
+//	client := secretsmanager.NewFromConfig(cfg)
+//
+//	creds, err := secretsmanager.GetExternalCredentials(ctx, client, "staging", tenantOrgID, "plugin-pix", "stripe")
+//	if err != nil {
+//	    // handle error
+//	}
+//
+//	apiKey := creds["api_key"]
+//
+// # Thread Safety
+//
+// GetExternalCredentials and BuildExternalSecretPath are safe for concurrent use.
+// No package-level mutable state is maintained.
+
+// Sentinel errors for external credential operations.
+// These mirror the M2M sentinels but are kept distinct so logs and error
+// classification can tell M2M and external-integration failures apart.
+var (
+	// ErrExternalCredentialsNotFound is returned when external credentials cannot be found at the expected path.
+	ErrExternalCredentialsNotFound = errors.New("external credentials not found")
+
+	// ErrExternalVaultAccessDenied is returned when access to the vault is denied (missing IAM permissions or expired tokens).
+	ErrExternalVaultAccessDenied = errors.New("vault access denied for external credentials")
+
+	// ErrExternalRetrievalFailed is returned when external credential retrieval fails due to infrastructure issues.
+	ErrExternalRetrievalFailed = errors.New("failed to retrieve external credentials")
+
+	// ErrExternalUnmarshalFailed is returned when the secret value cannot be deserialized into a key/value map.
+	ErrExternalUnmarshalFailed = errors.New("failed to unmarshal external credentials")
+
+	// ErrExternalInvalidInput is returned when required input parameters are missing.
+	ErrExternalInvalidInput = errors.New("invalid input for external credentials")
+
+	// ErrExternalInvalidCredentials is returned when the retrieved secret is an empty key/value map.
+	ErrExternalInvalidCredentials = errors.New("external credentials are empty")
+
+	// ErrExternalBinarySecretNotSupported is returned when the secret is stored as binary data rather than a string.
+	ErrExternalBinarySecretNotSupported = errors.New("binary secrets are not supported for external credentials")
+
+	// ErrExternalInvalidPathSegment is returned when a path segment contains path traversal characters.
+	ErrExternalInvalidPathSegment = errors.New("invalid path segment for external credentials")
+)
+
+// BuildExternalSecretPath constructs the secret path for external integration credentials.
+//
+// Format: tenants/{env}/{tenantOrgID}/{applicationName}/external/{targetService}/credentials
+//
+// When env is empty, the path omits the environment segment for backward compatibility:
+//
+//	tenants/{tenantOrgID}/{applicationName}/external/{targetService}/credentials
+//
+// This builder is exported so callers can construct paths without duplicating
+// the convention (e.g., provisioning tooling, integration tests).
+func BuildExternalSecretPath(env, tenantOrgID, applicationName, targetService string) string {
+	envPrefix := ""
+	if env != "" {
+		envPrefix = env + "/"
+	}
+
+	return fmt.Sprintf("tenants/%s%s/%s/external/%s/credentials", envPrefix, tenantOrgID, applicationName, targetService)
+}
+
+// GetExternalCredentials fetches external integration credentials from AWS Secrets Manager.
+//
+// Unlike GetM2MCredentials — which expects a strict {clientId, clientSecret} payload —
+// this function returns the secret as a free-form map[string]string because third-party
+// integrations vary in shape (api_key, webhook_secret, access_token, etc.).
+//
+// Parameters:
+//   - ctx: context for cancellation and tracing
+//   - client: AWS Secrets Manager client (must not be nil)
+//   - env: deployment environment (e.g., "staging", "production"); empty string is accepted for backward compatibility
+//   - tenantOrgID: resolved from request context (JWT owner claim); must not be empty
+//   - applicationName: the plugin or service name (e.g., "plugin-pix"); must not be empty
+//   - targetService: the third-party service name (e.g., "stripe", "twilio"); must not be empty
+//
+// Path convention:
+//
+//	tenants/{env}/{tenantOrgID}/{applicationName}/external/{targetService}/credentials
+//
+// Returns descriptive errors when:
+//   - client is nil
+//   - required parameters are missing or contain path traversal characters
+//   - secret not found at path
+//   - vault credentials are missing or expired
+//   - secret value is not a valid JSON object of string→string
+//   - secret value is binary (not supported)
+//   - secret value decodes to an empty map
+//
+// Safe for concurrent use (no shared mutable state).
+func GetExternalCredentials(ctx context.Context, client SecretsManagerClient, env, tenantOrgID, applicationName, targetService string) (map[string]string, error) {
+	// Validate inputs - check for typed-nil client using reflect
+	if isNilInterface(client) {
+		return nil, fmt.Errorf("%w: client is required", ErrExternalInvalidInput)
+	}
+
+	// Validate and sanitize path segments (trims whitespace, rejects traversal chars)
+	cleanTenantOrgID, err := validatePathSegmentWithErrors("tenantOrgID", tenantOrgID, ErrExternalInvalidInput, ErrExternalInvalidPathSegment)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanAppName, err := validatePathSegmentWithErrors("applicationName", applicationName, ErrExternalInvalidInput, ErrExternalInvalidPathSegment)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanTargetService, err := validatePathSegmentWithErrors("targetService", targetService, ErrExternalInvalidInput, ErrExternalInvalidPathSegment)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanEnv, err := validateOptionalEnv(env, ErrExternalInvalidPathSegment)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the secret path
+	secretPath := BuildExternalSecretPath(cleanEnv, cleanTenantOrgID, cleanAppName, cleanTargetService)
+	redacted := redactPath(secretPath)
+
+	// Fetch the secret from AWS Secrets Manager
+	input := &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(secretPath),
+	}
+
+	output, err := client.GetSecretValue(ctx, input)
+	if err != nil {
+		return nil, classifyAWSErrorWithSentinels(err, secretPath, ErrExternalCredentialsNotFound, ErrExternalVaultAccessDenied, ErrExternalRetrievalFailed)
+	}
+
+	// Check for binary secret FIRST (before attempting JSON unmarshal)
+	if output == nil || output.SecretString == nil {
+		return nil, fmt.Errorf("%w: secret at %s is binary or nil", ErrExternalBinarySecretNotSupported, redacted)
+	}
+
+	// Unmarshal as a free-form key/value map
+	creds := make(map[string]string)
+	if err := json.Unmarshal([]byte(*output.SecretString), &creds); err != nil {
+		return nil, fmt.Errorf("%w: secret at %s: %w", ErrExternalUnmarshalFailed, redacted, err)
+	}
+
+	// Reject empty payloads — an empty map is never a valid external credential set.
+	if len(creds) == 0 {
+		return nil, fmt.Errorf("%w: secret at %s: empty credential map", ErrExternalInvalidCredentials, redacted)
+	}
+
+	return creds, nil
+}

--- a/commons/secretsmanager/external_test.go
+++ b/commons/secretsmanager/external_test.go
@@ -1,0 +1,586 @@
+//go:build unit
+
+// Copyright Lerian Studio. All rights reserved.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package secretsmanager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	smithy "github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Test: BuildExternalSecretPath (path construction)
+// ============================================================================
+
+func TestBuildExternalSecretPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		env             string
+		tenantOrgID     string
+		applicationName string
+		targetService   string
+		expectedPath    string
+	}{
+		{
+			name:            "standard path with all parameters",
+			env:             "staging",
+			tenantOrgID:     "org_01KHVKQQP6D2N4RDJK0ADEKQX1",
+			applicationName: "plugin-pix",
+			targetService:   "stripe",
+			expectedPath:    "tenants/staging/org_01KHVKQQP6D2N4RDJK0ADEKQX1/plugin-pix/external/stripe/credentials",
+		},
+		{
+			name:            "production environment",
+			env:             "production",
+			tenantOrgID:     "org_02ABCDEF",
+			applicationName: "plugin-auth",
+			targetService:   "twilio",
+			expectedPath:    "tenants/production/org_02ABCDEF/plugin-auth/external/twilio/credentials",
+		},
+		{
+			name:            "empty env for backward compatibility",
+			env:             "",
+			tenantOrgID:     "org_01ABC",
+			applicationName: "plugin-crm",
+			targetService:   "salesforce",
+			expectedPath:    "tenants/org_01ABC/plugin-crm/external/salesforce/credentials",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := BuildExternalSecretPath(tt.env, tt.tenantOrgID, tt.applicationName, tt.targetService)
+
+			assert.Equal(t, tt.expectedPath, path)
+		})
+	}
+}
+
+// ============================================================================
+// Test: BuildM2MSecretPath (now exported, must still work)
+// ============================================================================
+
+func TestBuildM2MSecretPath_Exported(t *testing.T) {
+	t.Parallel()
+
+	path := BuildM2MSecretPath("staging", "org_01ABC", "plugin-pix", "ledger")
+	assert.Equal(t, "tenants/staging/org_01ABC/plugin-pix/m2m/ledger/credentials", path)
+
+	// Backward compat: empty env
+	pathNoEnv := BuildM2MSecretPath("", "org_01ABC", "plugin-pix", "ledger")
+	assert.Equal(t, "tenants/org_01ABC/plugin-pix/m2m/ledger/credentials", pathNoEnv)
+}
+
+// ============================================================================
+// Test: GetExternalCredentials - valid JSON deserialization (arbitrary keys)
+// ============================================================================
+
+func TestGetExternalCredentials_ValidJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		secretValue     string
+		env             string
+		tenantOrgID     string
+		applicationName string
+		targetService   string
+		expected        map[string]string
+	}{
+		{
+			name:            "api_key shape",
+			secretValue:     `{"api_key":"sk_live_123","api_secret":"shhh"}`,
+			env:             "staging",
+			tenantOrgID:     "org_01ABC",
+			applicationName: "plugin-pix",
+			targetService:   "stripe",
+			expected: map[string]string{
+				"api_key":    "sk_live_123",
+				"api_secret": "shhh",
+			},
+		},
+		{
+			name:            "webhook_secret shape",
+			secretValue:     `{"webhook_secret":"whsec_abc","webhook_url":"https://example.com/hook"}`,
+			env:             "production",
+			tenantOrgID:     "org_01ABC",
+			applicationName: "plugin-pix",
+			targetService:   "twilio",
+			expected: map[string]string{
+				"webhook_secret": "whsec_abc",
+				"webhook_url":    "https://example.com/hook",
+			},
+		},
+		{
+			name:            "single-key access_token",
+			secretValue:     `{"access_token":"tok_xyz"}`,
+			env:             "staging",
+			tenantOrgID:     "org_01ABC",
+			applicationName: "plugin-auth",
+			targetService:   "salesforce",
+			expected: map[string]string{
+				"access_token": "tok_xyz",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			secretPath := BuildExternalSecretPath(tt.env, tt.tenantOrgID, tt.applicationName, tt.targetService)
+
+			mock := &mockSecretsManagerClient{
+				secrets: map[string]string{
+					secretPath: tt.secretValue,
+				},
+				errors: map[string]error{},
+			}
+
+			creds, err := GetExternalCredentials(context.Background(), mock, tt.env, tt.tenantOrgID, tt.applicationName, tt.targetService)
+
+			require.NoError(t, err)
+			require.NotNil(t, creds)
+			assert.Equal(t, tt.expected, creds)
+		})
+	}
+}
+
+// ============================================================================
+// Test: GetExternalCredentials - invalid JSON deserialization
+// ============================================================================
+
+func TestGetExternalCredentials_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	secretPath := BuildExternalSecretPath("staging", "org_01ABC", "plugin-pix", "stripe")
+
+	tests := []struct {
+		name        string
+		secretValue string
+		expectedErr error
+	}{
+		{
+			name:        "malformed JSON",
+			secretValue: `{invalid-json`,
+			expectedErr: ErrExternalUnmarshalFailed,
+		},
+		{
+			name:        "empty string",
+			secretValue: ``,
+			expectedErr: ErrExternalUnmarshalFailed,
+		},
+		{
+			name:        "plain text instead of JSON",
+			secretValue: `not-json-at-all`,
+			expectedErr: ErrExternalUnmarshalFailed,
+		},
+		{
+			name:        "JSON array not object",
+			secretValue: `["foo","bar"]`,
+			expectedErr: ErrExternalUnmarshalFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &mockSecretsManagerClient{
+				secrets: map[string]string{
+					secretPath: tt.secretValue,
+				},
+				errors: map[string]error{},
+			}
+
+			creds, err := GetExternalCredentials(context.Background(), mock, "staging", "org_01ABC", "plugin-pix", "stripe")
+
+			require.ErrorIs(t, err, tt.expectedErr)
+			assert.Nil(t, creds)
+		})
+	}
+}
+
+// ============================================================================
+// Test: GetExternalCredentials - empty map rejected
+// ============================================================================
+
+func TestGetExternalCredentials_EmptyMap(t *testing.T) {
+	t.Parallel()
+
+	secretPath := BuildExternalSecretPath("staging", "org_01ABC", "plugin-pix", "stripe")
+
+	mock := &mockSecretsManagerClient{
+		secrets: map[string]string{
+			secretPath: `{}`,
+		},
+		errors: map[string]error{},
+	}
+
+	creds, err := GetExternalCredentials(context.Background(), mock, "staging", "org_01ABC", "plugin-pix", "stripe")
+
+	require.ErrorIs(t, err, ErrExternalInvalidCredentials)
+	assert.Nil(t, creds)
+}
+
+// ============================================================================
+// Test: GetExternalCredentials - secret not found
+// ============================================================================
+
+func TestGetExternalCredentials_SecretNotFound(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSecretsManagerClient{
+		secrets: map[string]string{},
+		errors:  map[string]error{},
+	}
+
+	creds, err := GetExternalCredentials(context.Background(), mock, "staging", "org_nonexistent", "plugin-pix", "stripe")
+
+	require.ErrorIs(t, err, ErrExternalCredentialsNotFound)
+	assert.Nil(t, creds)
+}
+
+// ============================================================================
+// Test: GetExternalCredentials - AWS access denied / token expired / generic
+// ============================================================================
+
+func TestGetExternalCredentials_AWSErrors(t *testing.T) {
+	t.Parallel()
+
+	secretPath := BuildExternalSecretPath("staging", "org_01ABC", "plugin-pix", "stripe")
+
+	tests := []struct {
+		name        string
+		awsError    error
+		expectedErr error
+	}{
+		{
+			name: "access denied",
+			awsError: &smithy.GenericAPIError{
+				Code:    "AccessDeniedException",
+				Message: "User is not authorized to access this resource",
+			},
+			expectedErr: ErrExternalVaultAccessDenied,
+		},
+		{
+			name: "credentials expired",
+			awsError: &smithy.GenericAPIError{
+				Code:    "ExpiredTokenException",
+				Message: "The security token included in the request is expired",
+			},
+			expectedErr: ErrExternalVaultAccessDenied,
+		},
+		{
+			name:        "generic AWS error",
+			awsError:    errors.New("InternalServiceError: service unavailable"),
+			expectedErr: ErrExternalRetrievalFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &mockSecretsManagerClient{
+				secrets: map[string]string{},
+				errors: map[string]error{
+					secretPath: tt.awsError,
+				},
+			}
+
+			creds, err := GetExternalCredentials(context.Background(), mock, "staging", "org_01ABC", "plugin-pix", "stripe")
+			require.ErrorIs(t, err, tt.expectedErr)
+			assert.Nil(t, creds)
+		})
+	}
+}
+
+// ============================================================================
+// Test: GetExternalCredentials - input validation
+// ============================================================================
+
+func TestGetExternalCredentials_InputValidation(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSecretsManagerClient{
+		secrets: map[string]string{},
+		errors:  map[string]error{},
+	}
+
+	tests := []struct {
+		name            string
+		env             string
+		tenantOrgID     string
+		applicationName string
+		targetService   string
+		expectedErr     error
+	}{
+		{
+			name:            "empty tenantOrgID",
+			env:             "staging",
+			tenantOrgID:     "",
+			applicationName: "plugin-pix",
+			targetService:   "stripe",
+			expectedErr:     ErrExternalInvalidInput,
+		},
+		{
+			name:            "empty applicationName",
+			env:             "staging",
+			tenantOrgID:     "org_01ABC",
+			applicationName: "",
+			targetService:   "stripe",
+			expectedErr:     ErrExternalInvalidInput,
+		},
+		{
+			name:            "empty targetService",
+			env:             "staging",
+			tenantOrgID:     "org_01ABC",
+			applicationName: "plugin-pix",
+			targetService:   "",
+			expectedErr:     ErrExternalInvalidInput,
+		},
+		{
+			name:            "whitespace-only tenantOrgID",
+			env:             "staging",
+			tenantOrgID:     "   ",
+			applicationName: "plugin-pix",
+			targetService:   "stripe",
+			expectedErr:     ErrExternalInvalidInput,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			creds, err := GetExternalCredentials(context.Background(), mock, tt.env, tt.tenantOrgID, tt.applicationName, tt.targetService)
+			require.ErrorIs(t, err, tt.expectedErr)
+			assert.Nil(t, creds)
+		})
+	}
+}
+
+// ============================================================================
+// Test: GetExternalCredentials - nil client (both untyped and typed nil)
+// ============================================================================
+
+func TestGetExternalCredentials_NilClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("untyped nil client", func(t *testing.T) {
+		t.Parallel()
+
+		creds, err := GetExternalCredentials(context.Background(), nil, "staging", "org_01ABC", "plugin-pix", "stripe")
+		require.ErrorIs(t, err, ErrExternalInvalidInput)
+		assert.Nil(t, creds)
+	})
+
+	t.Run("typed nil client", func(t *testing.T) {
+		t.Parallel()
+
+		var typedNil *mockSecretsManagerClient
+		creds, err := GetExternalCredentials(context.Background(), typedNil, "staging", "org_01ABC", "plugin-pix", "stripe")
+		require.ErrorIs(t, err, ErrExternalInvalidInput)
+		assert.Nil(t, creds)
+	})
+}
+
+// ============================================================================
+// Test: GetExternalCredentials - path traversal rejection
+// ============================================================================
+
+func TestGetExternalCredentials_PathTraversal(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSecretsManagerClient{
+		secrets: map[string]string{},
+		errors:  map[string]error{},
+	}
+
+	tests := []struct {
+		name            string
+		env             string
+		tenantOrgID     string
+		applicationName string
+		targetService   string
+		expectedErr     error
+	}{
+		{
+			name:            "tenantOrgID with slash",
+			env:             "staging",
+			tenantOrgID:     "org/../admin",
+			applicationName: "plugin-pix",
+			targetService:   "stripe",
+			expectedErr:     ErrExternalInvalidPathSegment,
+		},
+		{
+			name:            "applicationName with backslash",
+			env:             "staging",
+			tenantOrgID:     "org_01ABC",
+			applicationName: "plugin\\pix",
+			targetService:   "stripe",
+			expectedErr:     ErrExternalInvalidPathSegment,
+		},
+		{
+			name:            "targetService with dot-dot",
+			env:             "staging",
+			tenantOrgID:     "org_01ABC",
+			applicationName: "plugin-pix",
+			targetService:   "..secret",
+			expectedErr:     ErrExternalInvalidPathSegment,
+		},
+		{
+			name:            "env with traversal",
+			env:             "staging/../../admin",
+			tenantOrgID:     "org_01ABC",
+			applicationName: "plugin-pix",
+			targetService:   "stripe",
+			expectedErr:     ErrExternalInvalidPathSegment,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			creds, err := GetExternalCredentials(context.Background(), mock, tt.env, tt.tenantOrgID, tt.applicationName, tt.targetService)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.expectedErr)
+			assert.Nil(t, creds)
+		})
+	}
+}
+
+// ============================================================================
+// Test: GetExternalCredentials - binary secret not supported
+// ============================================================================
+
+func TestGetExternalCredentials_BinarySecret(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockBinarySecretsManagerClient{}
+
+	creds, err := GetExternalCredentials(context.Background(), mock, "staging", "org_01ABC", "plugin-pix", "stripe")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExternalBinarySecretNotSupported)
+	assert.Nil(t, creds)
+}
+
+// ============================================================================
+// Test: GetExternalCredentials - errors redact full path
+// ============================================================================
+
+func TestGetExternalCredentials_ErrorsDoNotLeakFullPath(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSecretsManagerClient{
+		secrets: map[string]string{},
+		errors:  map[string]error{},
+	}
+
+	_, err := GetExternalCredentials(context.Background(), mock, "staging", "org_01ABC", "plugin-pix", "stripe")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExternalCredentialsNotFound)
+	assert.NotContains(t, err.Error(), "tenants/staging/org_01ABC/plugin-pix/external/stripe/credentials")
+	assert.Contains(t, err.Error(), "credentials")
+}
+
+// ============================================================================
+// Test: GetExternalCredentials - whitespace trimming in segments
+// ============================================================================
+
+func TestGetExternalCredentials_WhitespaceTrimming(t *testing.T) {
+	t.Parallel()
+
+	secretValue := `{"api_key":"sk_test"}`
+	// Trimmed path should be used
+	secretPath := BuildExternalSecretPath("staging", "org_01ABC", "plugin-pix", "stripe")
+
+	mock := &mockSecretsManagerClient{
+		secrets: map[string]string{
+			secretPath: secretValue,
+		},
+		errors: map[string]error{},
+	}
+
+	creds, err := GetExternalCredentials(context.Background(), mock, " staging ", " org_01ABC ", " plugin-pix ", " stripe ")
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+	assert.Equal(t, "sk_test", creds["api_key"])
+}
+
+// ============================================================================
+// Test: GetExternalCredentials - concurrent safety
+// ============================================================================
+
+func TestGetExternalCredentials_ConcurrentSafety(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]string{
+		"api_key":    "sk_concurrent",
+		"api_secret": "shhh_concurrent",
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	secretPath := BuildExternalSecretPath("staging", "org_concurrent", "plugin-pix", "stripe")
+
+	mock := &mockSecretsManagerClient{
+		secrets: map[string]string{
+			secretPath: string(payloadJSON),
+		},
+		errors: map[string]error{},
+	}
+
+	const goroutineCount = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutineCount)
+
+	results := make([]map[string]string, goroutineCount)
+	errs := make([]error, goroutineCount)
+
+	for i := range goroutineCount {
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errs[idx] = GetExternalCredentials(
+				context.Background(),
+				mock,
+				"staging",
+				"org_concurrent",
+				"plugin-pix",
+				"stripe",
+			)
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i := range goroutineCount {
+		require.NoError(t, errs[i], "goroutine %d should not error", i)
+		require.NotNil(t, results[i], "goroutine %d should return credentials", i)
+		assert.Equal(t, "sk_concurrent", results[i]["api_key"], "goroutine %d should have correct api_key", i)
+		assert.Equal(t, "shhh_concurrent", results[i]["api_secret"], "goroutine %d should have correct api_secret", i)
+	}
+}

--- a/commons/secretsmanager/external_test.go
+++ b/commons/secretsmanager/external_test.go
@@ -196,6 +196,16 @@ func TestGetExternalCredentials_InvalidJSON(t *testing.T) {
 			secretValue: `["foo","bar"]`,
 			expectedErr: ErrExternalUnmarshalFailed,
 		},
+		{
+			name:        "JSON object with number value",
+			secretValue: `{"key":123}`,
+			expectedErr: ErrExternalUnmarshalFailed,
+		},
+		{
+			name:        "JSON object with bool value",
+			secretValue: `{"key":true}`,
+			expectedErr: ErrExternalUnmarshalFailed,
+		},
 	}
 
 	for _, tt := range tests {

--- a/commons/secretsmanager/m2m.go
+++ b/commons/secretsmanager/m2m.go
@@ -88,17 +88,41 @@ var (
 // validatePathSegment checks that a path segment is safe for use in secret paths.
 // It rejects segments containing path traversal characters (/, .., \) and
 // trims leading/trailing whitespace.
+//
+// This is the M2M-flavored wrapper; new code paths should use validatePathSegmentWithErrors
+// to wrap caller-specific sentinels (e.g., External*) instead of M2M*.
 func validatePathSegment(name, value string) (string, error) {
+	return validatePathSegmentWithErrors(name, value, ErrM2MInvalidInput, ErrM2MInvalidPathSegment)
+}
+
+// validatePathSegmentWithErrors is the generic validator that lets callers wrap
+// the result in their own sentinel errors. It rejects segments containing path
+// traversal characters (/, .., \) and trims leading/trailing whitespace.
+func validatePathSegmentWithErrors(name, value string, emptyErr, traversalErr error) (string, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
-		return "", fmt.Errorf("%w: %s is required", ErrM2MInvalidInput, name)
+		return "", fmt.Errorf("%w: %s is required", emptyErr, name)
 	}
 
 	if strings.Contains(trimmed, "/") || strings.Contains(trimmed, "\\") || strings.Contains(trimmed, "..") {
-		return "", fmt.Errorf("%w: %s contains path traversal characters", ErrM2MInvalidPathSegment, name)
+		return "", fmt.Errorf("%w: %s contains path traversal characters", traversalErr, name)
 	}
 
 	return trimmed, nil
+}
+
+// validateOptionalEnv applies the same traversal check to env, accepting empty values.
+func validateOptionalEnv(env string, traversalErr error) (string, error) {
+	cleanEnv := strings.TrimSpace(env)
+	if cleanEnv == "" {
+		return "", nil
+	}
+
+	if strings.Contains(cleanEnv, "/") || strings.Contains(cleanEnv, "\\") || strings.Contains(cleanEnv, "..") {
+		return "", fmt.Errorf("%w: env contains path traversal characters", traversalErr)
+	}
+
+	return cleanEnv, nil
 }
 
 // redactPath returns a safe representation of a secret path for error messages.
@@ -193,15 +217,13 @@ func GetM2MCredentials(ctx context.Context, client SecretsManagerClient, env, te
 	}
 
 	// env is optional (empty for backward compat) but must be safe if provided
-	cleanEnv := strings.TrimSpace(env)
-	if cleanEnv != "" {
-		if strings.Contains(cleanEnv, "/") || strings.Contains(cleanEnv, "\\") || strings.Contains(cleanEnv, "..") {
-			return nil, fmt.Errorf("%w: env contains path traversal characters", ErrM2MInvalidPathSegment)
-		}
+	cleanEnv, err := validateOptionalEnv(env, ErrM2MInvalidPathSegment)
+	if err != nil {
+		return nil, err
 	}
 
 	// Build the secret path
-	secretPath := buildM2MSecretPath(cleanEnv, cleanTenantOrgID, cleanAppName, cleanTargetService)
+	secretPath := BuildM2MSecretPath(cleanEnv, cleanTenantOrgID, cleanAppName, cleanTargetService)
 	redacted := redactPath(secretPath)
 
 	// Fetch the secret from AWS Secrets Manager
@@ -242,14 +264,17 @@ func GetM2MCredentials(ctx context.Context, client SecretsManagerClient, env, te
 	return &creds, nil
 }
 
-// buildM2MSecretPath constructs the secret path for M2M credentials.
+// BuildM2MSecretPath constructs the secret path for M2M credentials.
 //
 // Format: tenants/{env}/{tenantOrgID}/{applicationName}/m2m/{targetService}/credentials
 //
 // When env is empty, the path omits the environment segment for backward compatibility:
 //
 //	tenants/{tenantOrgID}/{applicationName}/m2m/{targetService}/credentials
-func buildM2MSecretPath(env, tenantOrgID, applicationName, targetService string) string {
+//
+// This builder is exported so callers (e.g., provisioning tooling, integration tests)
+// can construct paths without duplicating the convention.
+func BuildM2MSecretPath(env, tenantOrgID, applicationName, targetService string) string {
 	envPrefix := ""
 	if env != "" {
 		envPrefix = env + "/"
@@ -258,23 +283,30 @@ func buildM2MSecretPath(env, tenantOrgID, applicationName, targetService string)
 	return fmt.Sprintf("tenants/%s%s/%s/m2m/%s/credentials", envPrefix, tenantOrgID, applicationName, targetService)
 }
 
-// classifyAWSError maps AWS SDK errors to domain-specific sentinel errors.
+// classifyAWSError maps AWS SDK errors to M2M domain-specific sentinel errors.
 // Secret paths are redacted in returned errors to prevent information leakage.
 func classifyAWSError(err error, secretPath string) error {
+	return classifyAWSErrorWithSentinels(err, secretPath, ErrM2MCredentialsNotFound, ErrM2MVaultAccessDenied, ErrM2MRetrievalFailed)
+}
+
+// classifyAWSErrorWithSentinels is the generic AWS error classifier. Callers
+// pass the sentinel set they want to wrap (M2M or External, etc.). Secret paths
+// are redacted in returned errors to prevent information leakage.
+func classifyAWSErrorWithSentinels(err error, secretPath string, notFound, accessDenied, retrievalFailed error) error {
 	redacted := redactPath(secretPath)
 
 	var notFoundErr *smtypes.ResourceNotFoundException
 	if errors.As(err, &notFoundErr) {
-		return fmt.Errorf("%w at %s", ErrM2MCredentialsNotFound, redacted)
+		return fmt.Errorf("%w at %s", notFound, redacted)
 	}
 
 	var apiErr smithy.APIError
 	if errors.As(err, &apiErr) {
 		switch apiErr.ErrorCode() {
 		case "AccessDeniedException", "ExpiredTokenException":
-			return fmt.Errorf("%w: %w", ErrM2MVaultAccessDenied, err)
+			return fmt.Errorf("%w: %w", accessDenied, err)
 		}
 	}
 
-	return fmt.Errorf("%w: %s: %w", ErrM2MRetrievalFailed, redacted, err)
+	return fmt.Errorf("%w: %s: %w", retrievalFailed, redacted, err)
 }

--- a/commons/secretsmanager/m2m_test.go
+++ b/commons/secretsmanager/m2m_test.go
@@ -115,7 +115,7 @@ func TestBuildM2MSecretPath(t *testing.T) {
 			t.Parallel()
 
 			// Act
-			path := buildM2MSecretPath(tt.env, tt.tenantOrgID, tt.applicationName, tt.targetService)
+			path := BuildM2MSecretPath(tt.env, tt.tenantOrgID, tt.applicationName, tt.targetService)
 
 			// Assert
 			assert.Equal(t, tt.expectedPath, path)


### PR DESCRIPTION
## Summary

- Adds `BuildExternalSecretPath` and `GetExternalCredentials` to `commons/secretsmanager`, siblings of the existing M2M path builder/reader.
- External credentials follow the **same path convention** as M2M, just swapping the segment:
  - M2M: `tenants/{env}/{tenantOrgID}/{app}/m2m/{target}/credentials`
  - External: `tenants/{env}/{tenantOrgID}/{app}/external/{target}/credentials`
- External payload is `map[string]string` (arbitrary keys) because third-party integrations vary in shape (`api_key`, `webhook_secret`, `access_token`, etc.). M2M stays strict `{clientId, clientSecret}` — unchanged.
- Exports `BuildM2MSecretPath` (rename of previously unexported `buildM2MSecretPath`) so consumers like tenant-manager can build paths via the library instead of duplicating the format.
- Refactors `validatePathSegment`, optional-env handling, and AWS error classification into shared helpers parameterised by sentinel error sets — M2M and External behaviour stays aligned without code duplication.
- Dedicated `ErrExternal*` sentinel errors preserve log/metric separability between plugin↔product auth failures and third-party integration failures.

## Why

Consumers (tenant-manager today, others later) need a consistent, library-owned path format for external integration credentials. Until now, external credential paths were defined ad-hoc per consumer (`tenants/{env}/{tenant}/{service}-external-{target}-provider` in tenant-manager) with no shared builder and no shared reader — which made cross-service reuse impossible and the format drift-prone.

## Test plan

- [x] RED→GREEN cycle: `external_test.go` was written first; build failed with `undefined: BuildExternalSecretPath` etc., then passed after implementation.
- [x] `go test -tags=unit ./commons/secretsmanager/...` — 90 tests passing (41 new + 49 existing).
- [x] `go test -tags=unit ./...` — no regression across the full module.
- [x] `go build ./...` — clean.
- [x] `golangci-lint run --build-tags=unit ./...` — 0 issues.
- [x] Coverage includes: happy paths (multiple JSON shapes), path traversal rejection per segment + env, empty/whitespace input rejection, typed and untyped nil client, secret not found, access denied, expired token, binary secret, invalid JSON (including arrays), empty map, path redaction in errors, whitespace trimming, concurrent safety (50 goroutines), and that the renamed `BuildM2MSecretPath` export still works.

## API additions

```go
// BuildExternalSecretPath constructs the secret path for external credentials.
// Format: tenants/{env}/{tenantOrgID}/{applicationName}/external/{targetService}/credentials
// When env is empty, omits the environment segment for backward compatibility.
func BuildExternalSecretPath(env, tenantOrgID, applicationName, targetService string) string

// GetExternalCredentials fetches external integration credentials from AWS Secrets Manager.
// Returns the raw key/value map because third-party integrations vary in shape.
func GetExternalCredentials(ctx context.Context, client SecretsManagerClient, env, tenantOrgID, applicationName, targetService string) (map[string]string, error)

// BuildM2MSecretPath (renamed from buildM2MSecretPath, now exported).
func BuildM2MSecretPath(env, tenantOrgID, applicationName, targetService string) string

// Sentinel errors (mirror of ErrM2M* set):
ErrExternalCredentialsNotFound
ErrExternalVaultAccessDenied
ErrExternalRetrievalFailed
ErrExternalUnmarshalFailed
ErrExternalInvalidInput
ErrExternalInvalidCredentials
ErrExternalBinarySecretNotSupported
ErrExternalInvalidPathSegment
```

## Backward compatibility

- `BuildM2MSecretPath` was previously unexported — no public-API breakage (purely additive).
- `GetM2MCredentials` behaviour is unchanged; only the underlying validator/classifier helpers were refactored, with identical semantics verified by the existing test suite.
- No changes to imports, module path, or dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)