### PR TITLE
fix(ci): replace semantic-release backmerge plugin with dedicated workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,12 @@ jobs:
     with:
       enable_changelog: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit
+
+  backmerge:
+    if: github.ref == 'refs/heads/main'
+    needs: release
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@v1
+    with:
+      rules: '[{"from": "main", "to": "develop", "mode": "direct-with-pr-fallback"}]'
+      pr_labels: "backmerge,automated"
+    secrets: inherit

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -38,18 +38,6 @@ plugins:
     }]
   - "@semantic-release/exec"
 
-  # Plugin to automatically backmerge main → develop after a release,
-  # keeping develop in sync with hotfixes published from main.
-  - ["@saithodev/semantic-release-backmerge", {
-      backmergeBranches: [
-        {from: "main", to: "develop"}
-      ],
-      backmergeStrategy: "merge",
-      message: "chore(release): backmerge ${nextRelease.version} into ${branch.name}",
-      clearWorkspace: true,
-      restoreWorkspace: false
-    }]
-
 branches:
   - name: main
   - name: develop


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>Lib Commons</h1></td>
  </tr>
</table>

---

## Description

Substitui o plugin `@saithodev/semantic-release-backmerge` do `.releaserc.yml` por um job dedicado `backmerge` no `release.yml`, delegando para o reusable workflow `backmerge.yml` já existente no `github-actions-shared-workflows`.

**Problema:** o plugin usava uma cópia stale do `develop` (sem re-fetch antes do push), causando rejeição `non-fast-forward` sempre que `develop` tinha commits à frente de `main`. O erro ocorreu no release `v5.2.0` (run #26106380343).

**Solução:**
- O novo job `backmerge` só roda quando `github.ref == 'refs/heads/main'`, após o job `release` concluir
- Usa o `backmerge-sync` composite que faz fetch fresco do remoto antes do merge
- Modo `direct-with-pr-fallback`: tenta push direto; se rejeitado, abre PR automaticamente (nunca falha silenciosamente)

## Type of Change

- [x] `ci`: CI pipeline or workflow changes

## Breaking Changes

None.

## Testing

- [ ] `make test-unit` passes
- [ ] `make test-integration` passes if integration paths are exercised
- [ ] `make lint` passes
- [ ] `make sec` passes (gosec)
- [ ] Coverage threshold respected (see Go Combined Analysis)

**Test evidence / Actions run:** https://github.com/LerianStudio/lib-commons/actions/runs/26106380343/job/76771550169

## Architectural Checklist

- [x] Public v5 API contracts preserved (or `BREAKING CHANGE` flagged above)

## Related Issues

Closes #485