### PR TITLE
hotfix(tenant-manager): listener subscribes to env-scoped channel only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 
 ## [Unreleased]
 
+- Fixes:
+  - Multi-tenant event listener (`commons/tenant-manager/event.TenantEventListener`) now subscribes only to the env-scoped channel `tenant-events:{env}:` resolved via `commons.CurrentEnv()`. The previous wildcard `PSubscribe("tenant-events:*")` leaked events across environments (staging consumers receiving production events and vice versa) and defeated the env-scoped channel work shipped in v5.4.0.
+    - Behavior change: `Start()` now requires `ENVIRONMENT_NAME` (or `ENV_NAME`) to be set in the multi-tenant consumer process. Apps that wire `NewTenantEventListener` but do not set either env var will fail to start with an error referencing both variable names. Single-tenant apps that never wire the listener are unaffected.
+    - `event.SubscriptionPattern` is retained for backwards compatibility with custom subscriber implementations but is marked deprecated; the bundled listener no longer references it.
+    - Affected consumers (16) that wire `NewTenantEventListener`: br-ccs, br-sfn, br-sisbajud, br-spb-bc-correios, br-spi, br-sta, fetcher, flowker, go-boilerplate-ddd, lerian-notification, midaz, plugin-br-bank-transfer, plugin-fees, reporter, tracer, underwriter. Each needs `ENVIRONMENT_NAME` (or `ENV_NAME`) set to `staging` or `production` on the multi-tenant pod before bumping to v5.4.1.
+
 - Features:
   - Added `commons.CurrentEnv()` and `commons.MustCurrentEnv()` plus `EnvStaging` / `EnvProduction` helpers for consistent environment detection across services.
   - Added `commons/events.TenantEventsChannel(env)` and `TenantEventsChannelPrefix` to derive the canonical per-environment Redis Pub/Sub channel name for tenant lifecycle events.

--- a/commons/tenant-manager/event/listener.go
+++ b/commons/tenant-manager/event/listener.go
@@ -7,9 +7,12 @@ package event
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/redis/go-redis/v9"
 
+	"github.com/LerianStudio/lib-commons/v5/commons"
+	"github.com/LerianStudio/lib-commons/v5/commons/events"
 	"github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/internal/logcompat"
 	observability "github.com/LerianStudio/lib-observability"
 	libLog "github.com/LerianStudio/lib-observability/log"
@@ -79,9 +82,16 @@ func NewTenantEventListener(
 	return l, nil
 }
 
-// Start subscribes to the tenant-events pattern and spawns a goroutine to
-// read messages. Returns immediately after subscription is established.
-// The goroutine runs until Stop is called or the parent context is cancelled.
+// Start subscribes to the env-scoped tenant-events channel and spawns a
+// goroutine to read messages. Returns immediately after subscription is
+// established. The goroutine runs until Stop is called or the parent context
+// is cancelled.
+//
+// The runtime environment is resolved via commons.CurrentEnv(), which reads
+// ENVIRONMENT_NAME (or ENV_NAME). Start returns an error if neither variable
+// is set or the value is not one of the accepted environments.
+// Multi-tenant consumers MUST set ENVIRONMENT_NAME (or ENV_NAME) on the pod
+// before this listener can start.
 func (l *TenantEventListener) Start(ctx context.Context) error {
 	baseLogger, tracer, _, _ := observability.NewTrackingFromContext(ctx)
 	logger := logcompat.New(baseLogger)
@@ -93,16 +103,24 @@ func (l *TenantEventListener) Start(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "event.tenant_event_listener.start")
 	defer span.End()
 
+	env, err := commons.CurrentEnv()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "tenant event listener cannot resolve runtime environment", err)
+		return fmt.Errorf("tenant event listener cannot start: %w", err)
+	}
+
+	channel := events.TenantEventsChannel(env)
+
 	ctx, cancel := context.WithCancel(ctx)
 	l.cancel = cancel
 	l.done = make(chan struct{})
 
-	pubsub := l.redisClient.PSubscribe(ctx, SubscriptionPattern)
+	pubsub := l.redisClient.Subscribe(ctx, channel)
 
 	if l.service != "" {
-		logger.InfofCtx(ctx, "tenant event listener [%s] subscribed to pattern: %s", l.service, SubscriptionPattern)
+		logger.InfofCtx(ctx, "tenant event listener [%s] subscribed to channel: %s", l.service, channel)
 	} else {
-		logger.InfofCtx(ctx, "tenant event listener subscribed to pattern: %s", SubscriptionPattern)
+		logger.InfofCtx(ctx, "tenant event listener subscribed to channel: %s", channel)
 	}
 
 	go l.listen(ctx, pubsub)

--- a/commons/tenant-manager/event/listener_test.go
+++ b/commons/tenant-manager/event/listener_test.go
@@ -20,9 +20,28 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/LerianStudio/lib-commons/v5/commons/events"
 	"github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/internal/testutil"
 	"github.com/LerianStudio/lib-observability/log"
 )
+
+// setEnv sets ENVIRONMENT_NAME for the duration of the test and explicitly
+// clears ENV_NAME so the fallback path does not pollute the test. t.Setenv
+// restores both at test end and prevents the test from running in parallel
+// (env vars are process-global state).
+func setEnv(t *testing.T, value string) {
+	t.Helper()
+	t.Setenv("ENVIRONMENT_NAME", value)
+	t.Setenv("ENV_NAME", "")
+}
+
+// clearEnv removes both ENVIRONMENT_NAME and ENV_NAME for the duration of the
+// test. Used to verify that Start() fails fast when no env is configured.
+func clearEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("ENVIRONMENT_NAME", "")
+	t.Setenv("ENV_NAME", "")
+}
 
 // --------------------------------------------------------------------------
 // Constructor validation tests
@@ -92,8 +111,33 @@ func TestNewTenantEventListener_WithLogger(t *testing.T) {
 // Start / Stop lifecycle tests
 // --------------------------------------------------------------------------
 
+// TestTenantEventListener_Start_MissingEnvFailsFast verifies that Start()
+// returns an error when neither ENVIRONMENT_NAME nor ENV_NAME is set.
+// Multi-tenant consumers MUST configure one of the two on the pod.
+func TestTenantEventListener_Start_MissingEnvFailsFast(t *testing.T) {
+	clearEnv(t)
+
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	t.Cleanup(func() { client.Close() })
+
+	handler := func(_ context.Context, _ TenantLifecycleEvent) error { return nil }
+
+	listener, err := NewTenantEventListener(client, handler)
+	require.NoError(t, err)
+
+	err = listener.Start(context.Background())
+	require.Error(t, err)
+	// The wrapped error from commons.CurrentEnv() must mention both env var
+	// names so operators know either is accepted.
+	assert.Contains(t, err.Error(), "ENVIRONMENT_NAME")
+	assert.Contains(t, err.Error(), "ENV_NAME")
+	assert.Contains(t, err.Error(), "tenant event listener cannot start")
+}
+
 func TestTenantEventListener_StartStop(t *testing.T) {
-	t.Parallel()
+	setEnv(t, "staging")
 
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
@@ -118,7 +162,7 @@ func TestTenantEventListener_StartStop(t *testing.T) {
 }
 
 func TestTenantEventListener_ContextCancellation(t *testing.T) {
-	t.Parallel()
+	setEnv(t, "staging")
 
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
@@ -147,11 +191,226 @@ func TestTenantEventListener_ContextCancellation(t *testing.T) {
 }
 
 // --------------------------------------------------------------------------
-// Message dispatch tests
+// Channel-scoping tests — listener must subscribe ONLY to its env channel.
+// --------------------------------------------------------------------------
+
+// TestTenantEventListener_SubscribesToStagingChannel verifies that when
+// ENVIRONMENT_NAME=staging, Start() subscribes to tenant-events:staging:
+// and the listener receives events published on that channel.
+func TestTenantEventListener_SubscribesToStagingChannel(t *testing.T) {
+	setEnv(t, "staging")
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	t.Cleanup(func() { rdb.Close() })
+
+	var received atomic.Int32
+
+	handler := func(_ context.Context, _ TenantLifecycleEvent) error {
+		received.Add(1)
+		return nil
+	}
+
+	listener, err := NewTenantEventListener(rdb, handler)
+	require.NoError(t, err)
+
+	err = listener.Start(context.Background())
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	channel := events.TenantEventsChannel("staging")
+	assert.Equal(t, "tenant-events:staging:", channel)
+
+	evt := TenantLifecycleEvent{
+		EventID:     "evt-staging-001",
+		EventType:   EventTenantCreated,
+		Timestamp:   time.Now().UTC().Truncate(time.Second),
+		TenantID:    "t-stg",
+		TenantSlug:  "acme",
+		Environment: "staging",
+	}
+
+	data, marshalErr := json.Marshal(evt)
+	require.NoError(t, marshalErr)
+
+	publishCount := mr.Publish(channel, string(data))
+	require.Greater(t, publishCount, 0, "listener should be subscribed to tenant-events:staging:")
+
+	assert.Eventually(t, func() bool {
+		return received.Load() >= 1
+	}, 2*time.Second, 20*time.Millisecond, "handler should receive events on staging channel")
+
+	require.NoError(t, listener.Stop())
+}
+
+// TestTenantEventListener_SubscribesToProductionChannel mirrors the staging
+// case for ENVIRONMENT_NAME=production.
+func TestTenantEventListener_SubscribesToProductionChannel(t *testing.T) {
+	setEnv(t, "production")
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	t.Cleanup(func() { rdb.Close() })
+
+	var received atomic.Int32
+
+	handler := func(_ context.Context, _ TenantLifecycleEvent) error {
+		received.Add(1)
+		return nil
+	}
+
+	listener, err := NewTenantEventListener(rdb, handler)
+	require.NoError(t, err)
+
+	err = listener.Start(context.Background())
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	channel := events.TenantEventsChannel("production")
+	assert.Equal(t, "tenant-events:production:", channel)
+
+	evt := TenantLifecycleEvent{
+		EventID:     "evt-prod-001",
+		EventType:   EventTenantActivated,
+		Timestamp:   time.Now().UTC().Truncate(time.Second),
+		TenantID:    "t-prod",
+		TenantSlug:  "corp",
+		Environment: "production",
+	}
+
+	data, marshalErr := json.Marshal(evt)
+	require.NoError(t, marshalErr)
+
+	publishCount := mr.Publish(channel, string(data))
+	require.Greater(t, publishCount, 0, "listener should be subscribed to tenant-events:production:")
+
+	assert.Eventually(t, func() bool {
+		return received.Load() >= 1
+	}, 2*time.Second, 20*time.Millisecond, "handler should receive events on production channel")
+
+	require.NoError(t, listener.Stop())
+}
+
+// TestTenantEventListener_IgnoresLegacyPerTenantChannel verifies that the
+// listener does NOT receive events published on the legacy
+// tenant-events:{tenantID} channel — that channel format is still emitted by
+// tenant-manager during the transition but multi-tenant consumers must only
+// see events for their own environment.
+func TestTenantEventListener_IgnoresLegacyPerTenantChannel(t *testing.T) {
+	setEnv(t, "staging")
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	t.Cleanup(func() { rdb.Close() })
+
+	var received atomic.Int32
+
+	handler := func(_ context.Context, _ TenantLifecycleEvent) error {
+		received.Add(1)
+		return nil
+	}
+
+	listener, err := NewTenantEventListener(rdb, handler)
+	require.NoError(t, err)
+
+	err = listener.Start(context.Background())
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Publish to the LEGACY per-tenant channel "tenant-events:{tenantID}".
+	legacyChannel := ChannelForTenant("t-legacy")
+
+	evt := TenantLifecycleEvent{
+		EventID:     "evt-legacy-001",
+		EventType:   EventTenantCreated,
+		Timestamp:   time.Now().UTC().Truncate(time.Second),
+		TenantID:    "t-legacy",
+		TenantSlug:  "legacy",
+		Environment: "staging",
+	}
+
+	data, marshalErr := json.Marshal(evt)
+	require.NoError(t, marshalErr)
+
+	// miniredis.Publish returns subscriber count; with env-scoped subscribe
+	// the count for the legacy channel MUST be 0.
+	publishCount := mr.Publish(legacyChannel, string(data))
+	assert.Equal(t, 0, publishCount,
+		"listener must NOT be subscribed to legacy per-tenant channel %q", legacyChannel)
+
+	// Wait long enough that a stray delivery would have happened.
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, int32(0), received.Load(),
+		"handler must not be called for events on the legacy per-tenant channel")
+
+	require.NoError(t, listener.Stop())
+}
+
+// TestTenantEventListener_IgnoresOtherEnvChannel verifies that a listener
+// running with ENVIRONMENT_NAME=staging does not receive events published on
+// tenant-events:production: — i.e., cross-environment isolation holds.
+func TestTenantEventListener_IgnoresOtherEnvChannel(t *testing.T) {
+	setEnv(t, "staging")
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	t.Cleanup(func() { rdb.Close() })
+
+	var received atomic.Int32
+
+	handler := func(_ context.Context, _ TenantLifecycleEvent) error {
+		received.Add(1)
+		return nil
+	}
+
+	listener, err := NewTenantEventListener(rdb, handler)
+	require.NoError(t, err)
+
+	err = listener.Start(context.Background())
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	otherChannel := events.TenantEventsChannel("production")
+
+	evt := TenantLifecycleEvent{
+		EventID:     "evt-other-001",
+		EventType:   EventTenantCreated,
+		Timestamp:   time.Now().UTC().Truncate(time.Second),
+		TenantID:    "t-other",
+		TenantSlug:  "other",
+		Environment: "production",
+	}
+
+	data, marshalErr := json.Marshal(evt)
+	require.NoError(t, marshalErr)
+
+	publishCount := mr.Publish(otherChannel, string(data))
+	assert.Equal(t, 0, publishCount,
+		"staging listener must NOT be subscribed to %q", otherChannel)
+
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, int32(0), received.Load(),
+		"staging listener must not receive production events")
+
+	require.NoError(t, listener.Stop())
+}
+
+// --------------------------------------------------------------------------
+// Message dispatch tests — publish on the env-scoped channel.
 // --------------------------------------------------------------------------
 
 func TestTenantEventListener_ReceivesEvents(t *testing.T) {
-	t.Parallel()
+	setEnv(t, "staging")
 
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
@@ -198,8 +457,8 @@ func TestTenantEventListener_ReceivesEvents(t *testing.T) {
 	data, marshalErr := json.Marshal(evt)
 	require.NoError(t, marshalErr)
 
-	// Publish to the tenant's channel
-	channel := ChannelForTenant(evt.TenantID)
+	// Publish on the env-scoped channel that the listener actually subscribes to.
+	channel := events.TenantEventsChannel("staging")
 
 	publishCount := mr.Publish(channel, string(data))
 	require.Greater(t, publishCount, 0, "expected at least one subscriber to receive the message")
@@ -220,7 +479,7 @@ func TestTenantEventListener_ReceivesEvents(t *testing.T) {
 }
 
 func TestTenantEventListener_ParseError(t *testing.T) {
-	t.Parallel()
+	setEnv(t, "staging")
 
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
@@ -246,8 +505,8 @@ func TestTenantEventListener_ParseError(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	// Publish invalid JSON — should not crash, should be skipped
-	channel := ChannelForTenant("t-bad")
+	// Publish invalid JSON on the env-scoped channel — should not crash, should be skipped
+	channel := events.TenantEventsChannel("staging")
 
 	publishCount := mr.Publish(channel, "{invalid json")
 	require.Greater(t, publishCount, 0, "expected at least one subscriber")
@@ -267,7 +526,7 @@ func TestTenantEventListener_ParseError(t *testing.T) {
 }
 
 func TestTenantEventListener_HandlerError(t *testing.T) {
-	t.Parallel()
+	setEnv(t, "production")
 
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
@@ -295,7 +554,7 @@ func TestTenantEventListener_HandlerError(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	// Publish a valid event
+	// Publish a valid event on the env-scoped channel
 	evt := TenantLifecycleEvent{
 		EventID:     "evt-002",
 		EventType:   EventTenantActivated,
@@ -308,7 +567,7 @@ func TestTenantEventListener_HandlerError(t *testing.T) {
 	data, marshalErr := json.Marshal(evt)
 	require.NoError(t, marshalErr)
 
-	channel := ChannelForTenant(evt.TenantID)
+	channel := events.TenantEventsChannel("production")
 
 	publishCount := mr.Publish(channel, string(data))
 	require.Greater(t, publishCount, 0, "expected at least one subscriber")

--- a/commons/tenant-manager/event/types.go
+++ b/commons/tenant-manager/event/types.go
@@ -42,6 +42,13 @@ const (
 	ChannelPrefix = "tenant-events"
 
 	// SubscriptionPattern is the glob pattern to subscribe to all tenant event channels.
+	//
+	// Deprecated: The TenantEventListener no longer references this pattern; it
+	// subscribes to the env-scoped channel returned by
+	// commons/events.TenantEventsChannel(commons.CurrentEnv()) instead. The
+	// previous wildcard PSubscribe leaked events across environments. This
+	// constant is retained only for custom subscriber implementations outside
+	// the bundled listener; new code MUST NOT use it.
 	SubscriptionPattern = "tenant-events:*"
 )
 


### PR DESCRIPTION
## Summary

- Multi-tenant `TenantEventListener.Start()` now resolves env via `commons.CurrentEnv()` and `Subscribe(events.TenantEventsChannel(env))` instead of `PSubscribe("tenant-events:*")`, fixing cross-environment event leak.
- Listener fails fast at boot if neither `ENVIRONMENT_NAME` nor `ENV_NAME` is set in the multi-tenant consumer process — both env var names remain accepted, no operator migration required.
- `event.SubscriptionPattern` retained but marked deprecated for any custom subscriber implementations.

## Problem

v5.4.0 shipped `commons.CurrentEnv()` and `events.TenantEventsChannel(env)` but nothing inside lib-commons consumed them. The bundled `TenantEventListener` at `commons/tenant-manager/event/listener.go:100` was still calling `l.redisClient.PSubscribe(ctx, SubscriptionPattern)` with `SubscriptionPattern = "tenant-events:*"`. That wildcard subscribes to every tenant-events channel in the Valkey/Redis instance, including:

1. `tenant-events:staging:` (new env-scoped channel from tenant-manager PR #356)
2. `tenant-events:production:` (new env-scoped channel from tenant-manager PR #356)
3. `tenant-events:{tenantID}` (legacy per-tenant channel, still emitted during transition)

Result: a multi-tenant consumer running in staging would receive production tenant events, and vice versa. The cross-environment leak that v5.4.0 was supposed to close was still wide open in production end-to-end. This hotfix is the follow-up that actually wires the listener to use the env-scoped helpers.

## Behavior change

`Start(ctx)` previously always succeeded once the redis client was reachable. It now also requires the runtime environment to be configured:

```go
env, err := commons.CurrentEnv()  // reads ENVIRONMENT_NAME, falls back to ENV_NAME
if err != nil {
    return fmt.Errorf("tenant event listener cannot start: %w", err)
}
channel := events.TenantEventsChannel(env)            // "tenant-events:{env}:"
pubsub := l.redisClient.Subscribe(ctx, channel)       // explicit channel, not pattern
```

Both `ENVIRONMENT_NAME` and `ENV_NAME` are accepted (the existing `commons.CurrentEnv()` contract). Operators do NOT need to migrate from `ENV_NAME` to `ENVIRONMENT_NAME` — whichever is currently set in the deploy is fine.

If neither variable is set, `Start()` returns an error with the wrapped message from `commons.CurrentEnv()` (which already mentions both names), and the process exits during boot. Single-tenant apps that never wire the listener are unaffected.

## Operator action — multi-tenant consumers

Each of these 16 LerianStudio repos wires `NewTenantEventListener` and runs in multi-tenant mode. Each needs `ENVIRONMENT_NAME` (or `ENV_NAME`) set to `staging` or `production` on the multi-tenant pod before bumping to v5.4.1:

- br-ccs
- br-sfn
- br-sisbajud
- br-spb-bc-correios
- br-spi
- br-sta
- fetcher
- flowker
- go-boilerplate-ddd
- lerian-notification
- midaz
- plugin-br-bank-transfer
- plugin-fees
- reporter
- tracer
- underwriter

Most of these already set `ENV_NAME` for other lib-commons code paths — those deploys will work unchanged. Deploys that previously relied on implicit env detection must add the variable.

## Files changed

| File | Change |
|------|--------|
| `commons/tenant-manager/event/listener.go` | `Start()` resolves env via `commons.CurrentEnv()`, subscribes to env-scoped channel only (~+30 lines net) |
| `commons/tenant-manager/event/listener_test.go` | Adds missing-env / staging / production / legacy-channel-ignored / cross-env-ignored tests; existing tests now publish on the env-scoped channel and set env via `t.Setenv` (~+265 lines net) |
| `commons/tenant-manager/event/types.go` | Adds deprecation godoc on `SubscriptionPattern` (kept for custom subscribers) (+7 lines) |
| `CHANGELOG.md` | Unreleased "Fixes" entry with the 16 consumer list and operator action |

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -tags=unit -count=1 -short ./...` — 4577 passed across 50 packages
- [x] `gofmt -l` clean on touched files
- [x] `golangci-lint run ./commons/tenant-manager/event/...` — no issues
- [x] New test `TestTenantEventListener_Start_MissingEnvFailsFast` verifies error path when neither env var is set, asserting the error mentions both `ENVIRONMENT_NAME` and `ENV_NAME`
- [x] New test `TestTenantEventListener_SubscribesToStagingChannel` verifies subscribe to `tenant-events:staging:` and event reception
- [x] New test `TestTenantEventListener_SubscribesToProductionChannel` verifies subscribe to `tenant-events:production:` and event reception
- [x] New test `TestTenantEventListener_IgnoresLegacyPerTenantChannel` confirms via `miniredis.Publish` subscriber count == 0 that the legacy `tenant-events:{tenantID}` channel is NOT received
- [x] New test `TestTenantEventListener_IgnoresOtherEnvChannel` confirms staging listener receives 0 subscribers for production channel

## Post-merge

- Tag `v5.4.1` on `main`
- Tracker should coordinate the 16 consumer bumps; each needs the env var present in the multi-tenant pod deploy before upgrading

## Out of scope

- No changes to `commons/env.go`, `commons/events/tenant_events.go`, `commons/security.go` — all shipped in v5.4.0
- No consumer-repo changes
- No backward-compat option (no `WithEnv`, no fallback to wildcard). Wiring the listener IS multi-tenant mode; multi-tenant mode requires env. The activation is implicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)