### PR TITLE
fix(events): backport env helpers + env-scoped listener to v4.6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
 # Changelog
 
 All notable changes to lib-commons will be documented in this file.
+
+## [v4.6.2] — 2026-05-30 (backport hotfix)
+
+### Added (backport from v5.4.0)
+- `commons.CurrentEnv()` / `commons.MustCurrentEnv()` — reads `ENVIRONMENT_NAME` (preferred) or `ENV_NAME` (also accepted), validates value is `staging` or `production`.
+- `commons.EnvStaging`, `commons.EnvProduction` constants.
+- `events.TenantEventsChannel(env)` — returns `"tenant-events:{env}:"`.
+- `events.TenantEventsChannelPrefix` constant.
+
+### Fixed (backport from v5.4.1)
+- Multi-tenant event listener (`commons/tenant-manager/event.TenantEventListener`) now subscribes ONLY to the env-scoped channel `tenant-events:{env}:` (resolved via `commons.CurrentEnv()`). The previous wildcard `PSubscribe("tenant-events:*")` leaked events across environments. `Start()` now requires `ENVIRONMENT_NAME` (or `ENV_NAME`) to be set in the multi-tenant consumer process — apps that wire `NewTenantEventListener` but do not set the env var will fail to start. Single-tenant apps that never wire the listener are unaffected.
+
+### Deprecated
+- `event.SubscriptionPattern` (`"tenant-events:*"`) — retained for backward compatibility but no longer used by the listener. Use `events.TenantEventsChannel(commons.CurrentEnv())` instead. Subscribing to the legacy wildcard leaks events across environments.
+
+### NOT backported (left in v5.x line)
+- Security framework simplification (`security_override.go` removal, `SecurityTier`, `CheckSecurityRule`, etc.)
+- Rate limit env var changes (`RATE_LIMIT_ENABLED` default flip, `ALLOW_RATELIMIT_DISABLED` removal)
+- Other v4.6.2 — v5.4.x improvements
+
+Apps that want any of the above must migrate to lib-commons/v5.

--- a/commons/env.go
+++ b/commons/env.go
@@ -1,0 +1,50 @@
+package commons
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Environment identifiers accepted by CurrentEnv. Keep this list aligned with
+// downstream services' deploy manifests.
+const (
+	EnvStaging    = "staging"
+	EnvProduction = "production"
+)
+
+// CurrentEnv reads the runtime environment from ENVIRONMENT_NAME (preferred)
+// or ENV_NAME (also accepted). The value is normalised to lowercase and
+// trimmed. Returns an error if the variable is unset, empty, or not one of
+// the accepted values (staging, production).
+//
+// Callers MUST handle the error — env mis-configuration should fail-fast at
+// boot, never silently default.
+func CurrentEnv() (string, error) {
+	raw := os.Getenv("ENVIRONMENT_NAME")
+	if raw == "" {
+		raw = os.Getenv("ENV_NAME")
+	}
+
+	env := strings.ToLower(strings.TrimSpace(raw))
+	switch env {
+	case EnvStaging, EnvProduction:
+		return env, nil
+	case "":
+		return "", fmt.Errorf("ENVIRONMENT_NAME (or ENV_NAME) is required: must be %q or %q", EnvStaging, EnvProduction)
+	default:
+		return "", fmt.Errorf("invalid environment %q: must be %q or %q", env, EnvStaging, EnvProduction)
+	}
+}
+
+// MustCurrentEnv is CurrentEnv that panics on error. Intended for bootstrap
+// where a misconfigured env is unrecoverable. Prefer CurrentEnv in library
+// code; reserve MustCurrentEnv for application main packages.
+func MustCurrentEnv() string {
+	env, err := CurrentEnv()
+	if err != nil {
+		panic(err)
+	}
+
+	return env
+}

--- a/commons/env_test.go
+++ b/commons/env_test.go
@@ -1,0 +1,173 @@
+//go:build unit
+
+package commons
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCurrentEnv(t *testing.T) {
+	tests := []struct {
+		name           string
+		environmentVar string
+		envNameVar     string
+		want           string
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:           "reads ENVIRONMENT_NAME (preferred)",
+			environmentVar: "staging",
+			want:           "staging",
+		},
+		{
+			name:           "reads ENVIRONMENT_NAME for production",
+			environmentVar: "production",
+			want:           "production",
+		},
+		{
+			name:       "accepts ENV_NAME when ENVIRONMENT_NAME unset",
+			envNameVar: "staging",
+			want:       "staging",
+		},
+		{
+			name:           "ENVIRONMENT_NAME wins over ENV_NAME",
+			environmentVar: "production",
+			envNameVar:     "staging",
+			want:           "production",
+		},
+		{
+			name:       "accepts ENV_NAME for production",
+			envNameVar: "production",
+			want:       "production",
+		},
+		{
+			name:           "case-insensitive uppercase",
+			environmentVar: "STAGING",
+			want:           "staging",
+		},
+		{
+			name:           "case-insensitive mixed case",
+			environmentVar: "Production",
+			want:           "production",
+		},
+		{
+			name:           "trims whitespace",
+			environmentVar: "  staging  ",
+			want:           "staging",
+		},
+		{
+			name:           "trims tabs and newlines",
+			environmentVar: "\tstaging\n",
+			want:           "staging",
+		},
+		{
+			name:        "rejects when both unset",
+			wantErr:     true,
+			errContains: "is required",
+		},
+		{
+			name:           "rejects empty string in ENVIRONMENT_NAME with ENV_NAME also empty",
+			environmentVar: "",
+			envNameVar:     "",
+			wantErr:        true,
+			errContains:    "is required",
+		},
+		{
+			name:           "rejects whitespace-only value",
+			environmentVar: "   ",
+			wantErr:        true,
+			errContains:    "is required",
+		},
+		{
+			name:           "rejects unknown value 'dev'",
+			environmentVar: "dev",
+			wantErr:        true,
+			errContains:    "invalid environment",
+		},
+		{
+			name:           "rejects unknown value 'uat'",
+			environmentVar: "uat",
+			wantErr:        true,
+			errContains:    "invalid environment",
+		},
+		{
+			name:           "rejects unknown value 'local'",
+			environmentVar: "local",
+			wantErr:        true,
+			errContains:    "invalid environment",
+		},
+		{
+			name:           "rejects unknown value 'prod' (must be full word)",
+			environmentVar: "prod",
+			wantErr:        true,
+			errContains:    "invalid environment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("ENVIRONMENT_NAME", tt.environmentVar)
+			t.Setenv("ENV_NAME", tt.envNameVar)
+
+			got, err := CurrentEnv()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("CurrentEnv() expected error, got nil (value=%q)", got)
+				}
+
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("CurrentEnv() error = %q, want substring %q", err.Error(), tt.errContains)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("CurrentEnv() unexpected error: %v", err)
+			}
+
+			if got != tt.want {
+				t.Errorf("CurrentEnv() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMustCurrentEnv_Success(t *testing.T) {
+	t.Setenv("ENVIRONMENT_NAME", "production")
+	t.Setenv("ENV_NAME", "")
+
+	got := MustCurrentEnv()
+	if got != "production" {
+		t.Errorf("MustCurrentEnv() = %q, want %q", got, "production")
+	}
+}
+
+func TestMustCurrentEnv_PanicsOnUnset(t *testing.T) {
+	t.Setenv("ENVIRONMENT_NAME", "")
+	t.Setenv("ENV_NAME", "")
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("MustCurrentEnv() expected panic, did not panic")
+		}
+	}()
+
+	_ = MustCurrentEnv()
+}
+
+func TestMustCurrentEnv_PanicsOnInvalid(t *testing.T) {
+	t.Setenv("ENVIRONMENT_NAME", "qa")
+	t.Setenv("ENV_NAME", "")
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("MustCurrentEnv() expected panic, did not panic")
+		}
+	}()
+
+	_ = MustCurrentEnv()
+}

--- a/commons/events/tenant_events.go
+++ b/commons/events/tenant_events.go
@@ -1,0 +1,26 @@
+// Package events provides constants and helpers for inter-service event
+// channels used by Lerian Go services.
+package events
+
+// TenantEventsChannelPrefix is the base prefix for tenant lifecycle event
+// channels. The full channel name is composed as
+// TenantEventsChannelPrefix + env + ":".
+const TenantEventsChannelPrefix = "tenant-events:"
+
+// TenantEventsChannel returns the env-scoped Valkey pub/sub channel for
+// tenant lifecycle events. Pair with commons.CurrentEnv() at subscriber
+// boot:
+//
+//	env, err := commons.CurrentEnv()
+//	if err != nil { return err }
+//	channel := events.TenantEventsChannel(env)  // "tenant-events:staging:"
+//	pubsub := redisClient.Subscribe(ctx, channel)
+//
+// The returned channel name has a trailing colon. Do NOT append anything to
+// it without explicit coordination with the publisher (tenant-manager).
+//
+// This function does NOT validate the env value. Callers MUST validate
+// upstream via commons.CurrentEnv() to ensure the channel name is well-formed.
+func TenantEventsChannel(env string) string {
+	return TenantEventsChannelPrefix + env + ":"
+}

--- a/commons/events/tenant_events_test.go
+++ b/commons/events/tenant_events_test.go
@@ -1,0 +1,48 @@
+//go:build unit
+
+package events
+
+import "testing"
+
+func TestTenantEventsChannel(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{
+			name: "staging produces env-scoped channel",
+			env:  "staging",
+			want: "tenant-events:staging:",
+		},
+		{
+			name: "production produces env-scoped channel",
+			env:  "production",
+			want: "tenant-events:production:",
+		},
+		{
+			// Documents that this function does NOT validate. Callers must
+			// validate the env upstream via commons.CurrentEnv() — passing
+			// an empty string here yields a malformed channel name.
+			name: "empty env yields malformed channel (caller-validation contract)",
+			env:  "",
+			want: "tenant-events::",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TenantEventsChannel(tt.env)
+			if got != tt.want {
+				t.Errorf("TenantEventsChannel(%q) = %q, want %q", tt.env, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTenantEventsChannelPrefix(t *testing.T) {
+	const want = "tenant-events:"
+	if TenantEventsChannelPrefix != want {
+		t.Errorf("TenantEventsChannelPrefix = %q, want %q", TenantEventsChannelPrefix, want)
+	}
+}

--- a/commons/tenant-manager/event/listener.go
+++ b/commons/tenant-manager/event/listener.go
@@ -7,10 +7,12 @@ package event
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/redis/go-redis/v9"
 
 	libCommons "github.com/LerianStudio/lib-commons/v4/commons"
+	"github.com/LerianStudio/lib-commons/v4/commons/events"
 	libLog "github.com/LerianStudio/lib-commons/v4/commons/log"
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v4/commons/opentelemetry"
 	"github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/internal/logcompat"
@@ -79,9 +81,21 @@ func NewTenantEventListener(
 	return l, nil
 }
 
-// Start subscribes to the tenant-events pattern and spawns a goroutine to
-// read messages. Returns immediately after subscription is established.
-// The goroutine runs until Stop is called or the parent context is cancelled.
+// Start subscribes to the env-scoped tenant-events channel and spawns a
+// goroutine to read messages. Returns immediately after subscription is
+// established. The goroutine runs until Stop is called or the parent context
+// is cancelled.
+//
+// The runtime environment is resolved via commons.CurrentEnv(), which reads
+// ENVIRONMENT_NAME (preferred) or ENV_NAME (also accepted). Start returns an
+// error if neither variable is set or the value is not one of the accepted
+// environments. Multi-tenant consumers MUST set ENVIRONMENT_NAME (or
+// ENV_NAME) on the pod before this listener can start — otherwise a
+// cross-environment event leak is possible.
+//
+// Wiring NewTenantEventListener IS the activation of multi-tenant mode.
+// Single-tenant apps that never wire NewTenantEventListener are unaffected
+// by this env-var requirement.
 func (l *TenantEventListener) Start(ctx context.Context) error {
 	baseLogger, tracer, _, _ := libCommons.NewTrackingFromContext(ctx)
 	logger := logcompat.New(baseLogger)
@@ -93,16 +107,24 @@ func (l *TenantEventListener) Start(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "event.tenant_event_listener.start")
 	defer span.End()
 
+	env, err := libCommons.CurrentEnv()
+	if err != nil {
+		libOpentelemetry.HandleSpanError(span, "tenant event listener cannot resolve runtime environment", err)
+		return fmt.Errorf("tenant event listener cannot start: %w", err)
+	}
+
+	channel := events.TenantEventsChannel(env)
+
 	ctx, cancel := context.WithCancel(ctx)
 	l.cancel = cancel
 	l.done = make(chan struct{})
 
-	pubsub := l.redisClient.PSubscribe(ctx, SubscriptionPattern)
+	pubsub := l.redisClient.Subscribe(ctx, channel)
 
 	if l.service != "" {
-		logger.InfofCtx(ctx, "tenant event listener [%s] subscribed to pattern: %s", l.service, SubscriptionPattern)
+		logger.InfofCtx(ctx, "tenant event listener [%s] subscribed to channel: %s", l.service, channel)
 	} else {
-		logger.InfofCtx(ctx, "tenant event listener subscribed to pattern: %s", SubscriptionPattern)
+		logger.InfofCtx(ctx, "tenant event listener subscribed to channel: %s", channel)
 	}
 
 	go l.listen(ctx, pubsub)

--- a/commons/tenant-manager/event/listener_test.go
+++ b/commons/tenant-manager/event/listener_test.go
@@ -20,9 +20,28 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/LerianStudio/lib-commons/v4/commons/events"
 	"github.com/LerianStudio/lib-commons/v4/commons/log"
 	"github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/internal/testutil"
 )
+
+// setEnv sets ENVIRONMENT_NAME for the duration of the test and explicitly
+// clears ENV_NAME so the fallback path does not pollute the test. t.Setenv
+// restores both at test end and prevents the test from running in parallel
+// (env vars are process-global state).
+func setEnv(t *testing.T, value string) {
+	t.Helper()
+	t.Setenv("ENVIRONMENT_NAME", value)
+	t.Setenv("ENV_NAME", "")
+}
+
+// clearEnv removes both ENVIRONMENT_NAME and ENV_NAME for the duration of the
+// test. Used to verify that Start() fails fast when no env is configured.
+func clearEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("ENVIRONMENT_NAME", "")
+	t.Setenv("ENV_NAME", "")
+}
 
 // --------------------------------------------------------------------------
 // Constructor validation tests
@@ -92,8 +111,33 @@ func TestNewTenantEventListener_WithLogger(t *testing.T) {
 // Start / Stop lifecycle tests
 // --------------------------------------------------------------------------
 
+// TestTenantEventListener_Start_MissingEnvFailsFast verifies that Start()
+// returns an error when neither ENVIRONMENT_NAME nor ENV_NAME is set.
+// Multi-tenant consumers MUST configure one of the two on the pod.
+func TestTenantEventListener_Start_MissingEnvFailsFast(t *testing.T) {
+	clearEnv(t)
+
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	t.Cleanup(func() { client.Close() })
+
+	handler := func(_ context.Context, _ TenantLifecycleEvent) error { return nil }
+
+	listener, err := NewTenantEventListener(client, handler)
+	require.NoError(t, err)
+
+	err = listener.Start(context.Background())
+	require.Error(t, err)
+	// The wrapped error from commons.CurrentEnv() must mention both env var
+	// names so operators know either is accepted.
+	assert.Contains(t, err.Error(), "ENVIRONMENT_NAME")
+	assert.Contains(t, err.Error(), "ENV_NAME")
+	assert.Contains(t, err.Error(), "tenant event listener cannot start")
+}
+
 func TestTenantEventListener_StartStop(t *testing.T) {
-	t.Parallel()
+	setEnv(t, "staging")
 
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
@@ -118,7 +162,7 @@ func TestTenantEventListener_StartStop(t *testing.T) {
 }
 
 func TestTenantEventListener_ContextCancellation(t *testing.T) {
-	t.Parallel()
+	setEnv(t, "staging")
 
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
@@ -147,11 +191,226 @@ func TestTenantEventListener_ContextCancellation(t *testing.T) {
 }
 
 // --------------------------------------------------------------------------
-// Message dispatch tests
+// Channel-scoping tests — listener must subscribe ONLY to its env channel.
+// --------------------------------------------------------------------------
+
+// TestTenantEventListener_SubscribesToStagingChannel verifies that when
+// ENVIRONMENT_NAME=staging, Start() subscribes to tenant-events:staging:
+// and the listener receives events published on that channel.
+func TestTenantEventListener_SubscribesToStagingChannel(t *testing.T) {
+	setEnv(t, "staging")
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	t.Cleanup(func() { rdb.Close() })
+
+	var received atomic.Int32
+
+	handler := func(_ context.Context, _ TenantLifecycleEvent) error {
+		received.Add(1)
+		return nil
+	}
+
+	listener, err := NewTenantEventListener(rdb, handler)
+	require.NoError(t, err)
+
+	err = listener.Start(context.Background())
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	channel := events.TenantEventsChannel("staging")
+	assert.Equal(t, "tenant-events:staging:", channel)
+
+	evt := TenantLifecycleEvent{
+		EventID:     "evt-staging-001",
+		EventType:   EventTenantCreated,
+		Timestamp:   time.Now().UTC().Truncate(time.Second),
+		TenantID:    "t-stg",
+		TenantSlug:  "acme",
+		Environment: "staging",
+	}
+
+	data, marshalErr := json.Marshal(evt)
+	require.NoError(t, marshalErr)
+
+	publishCount := mr.Publish(channel, string(data))
+	require.Greater(t, publishCount, 0, "listener should be subscribed to tenant-events:staging:")
+
+	assert.Eventually(t, func() bool {
+		return received.Load() >= 1
+	}, 2*time.Second, 20*time.Millisecond, "handler should receive events on staging channel")
+
+	require.NoError(t, listener.Stop())
+}
+
+// TestTenantEventListener_SubscribesToProductionChannel mirrors the staging
+// case for ENVIRONMENT_NAME=production.
+func TestTenantEventListener_SubscribesToProductionChannel(t *testing.T) {
+	setEnv(t, "production")
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	t.Cleanup(func() { rdb.Close() })
+
+	var received atomic.Int32
+
+	handler := func(_ context.Context, _ TenantLifecycleEvent) error {
+		received.Add(1)
+		return nil
+	}
+
+	listener, err := NewTenantEventListener(rdb, handler)
+	require.NoError(t, err)
+
+	err = listener.Start(context.Background())
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	channel := events.TenantEventsChannel("production")
+	assert.Equal(t, "tenant-events:production:", channel)
+
+	evt := TenantLifecycleEvent{
+		EventID:     "evt-prod-001",
+		EventType:   EventTenantActivated,
+		Timestamp:   time.Now().UTC().Truncate(time.Second),
+		TenantID:    "t-prod",
+		TenantSlug:  "corp",
+		Environment: "production",
+	}
+
+	data, marshalErr := json.Marshal(evt)
+	require.NoError(t, marshalErr)
+
+	publishCount := mr.Publish(channel, string(data))
+	require.Greater(t, publishCount, 0, "listener should be subscribed to tenant-events:production:")
+
+	assert.Eventually(t, func() bool {
+		return received.Load() >= 1
+	}, 2*time.Second, 20*time.Millisecond, "handler should receive events on production channel")
+
+	require.NoError(t, listener.Stop())
+}
+
+// TestTenantEventListener_IgnoresLegacyPerTenantChannel verifies that the
+// listener does NOT receive events published on the legacy
+// tenant-events:{tenantID} channel — that channel format is still emitted by
+// tenant-manager during the transition but multi-tenant consumers must only
+// see events for their own environment.
+func TestTenantEventListener_IgnoresLegacyPerTenantChannel(t *testing.T) {
+	setEnv(t, "staging")
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	t.Cleanup(func() { rdb.Close() })
+
+	var received atomic.Int32
+
+	handler := func(_ context.Context, _ TenantLifecycleEvent) error {
+		received.Add(1)
+		return nil
+	}
+
+	listener, err := NewTenantEventListener(rdb, handler)
+	require.NoError(t, err)
+
+	err = listener.Start(context.Background())
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Publish to the LEGACY per-tenant channel "tenant-events:{tenantID}".
+	legacyChannel := ChannelForTenant("t-legacy")
+
+	evt := TenantLifecycleEvent{
+		EventID:     "evt-legacy-001",
+		EventType:   EventTenantCreated,
+		Timestamp:   time.Now().UTC().Truncate(time.Second),
+		TenantID:    "t-legacy",
+		TenantSlug:  "legacy",
+		Environment: "staging",
+	}
+
+	data, marshalErr := json.Marshal(evt)
+	require.NoError(t, marshalErr)
+
+	// miniredis.Publish returns subscriber count; with env-scoped subscribe
+	// the count for the legacy channel MUST be 0.
+	publishCount := mr.Publish(legacyChannel, string(data))
+	assert.Equal(t, 0, publishCount,
+		"listener must NOT be subscribed to legacy per-tenant channel %q", legacyChannel)
+
+	// Wait long enough that a stray delivery would have happened.
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, int32(0), received.Load(),
+		"handler must not be called for events on the legacy per-tenant channel")
+
+	require.NoError(t, listener.Stop())
+}
+
+// TestTenantEventListener_IgnoresOtherEnvChannel verifies that a listener
+// running with ENVIRONMENT_NAME=staging does not receive events published on
+// tenant-events:production: — i.e., cross-environment isolation holds.
+func TestTenantEventListener_IgnoresOtherEnvChannel(t *testing.T) {
+	setEnv(t, "staging")
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	t.Cleanup(func() { rdb.Close() })
+
+	var received atomic.Int32
+
+	handler := func(_ context.Context, _ TenantLifecycleEvent) error {
+		received.Add(1)
+		return nil
+	}
+
+	listener, err := NewTenantEventListener(rdb, handler)
+	require.NoError(t, err)
+
+	err = listener.Start(context.Background())
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	otherChannel := events.TenantEventsChannel("production")
+
+	evt := TenantLifecycleEvent{
+		EventID:     "evt-other-001",
+		EventType:   EventTenantCreated,
+		Timestamp:   time.Now().UTC().Truncate(time.Second),
+		TenantID:    "t-other",
+		TenantSlug:  "other",
+		Environment: "production",
+	}
+
+	data, marshalErr := json.Marshal(evt)
+	require.NoError(t, marshalErr)
+
+	publishCount := mr.Publish(otherChannel, string(data))
+	assert.Equal(t, 0, publishCount,
+		"staging listener must NOT be subscribed to %q", otherChannel)
+
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, int32(0), received.Load(),
+		"staging listener must not receive production events")
+
+	require.NoError(t, listener.Stop())
+}
+
+// --------------------------------------------------------------------------
+// Message dispatch tests — publish on the env-scoped channel.
 // --------------------------------------------------------------------------
 
 func TestTenantEventListener_ReceivesEvents(t *testing.T) {
-	t.Parallel()
+	setEnv(t, "staging")
 
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
@@ -198,8 +457,8 @@ func TestTenantEventListener_ReceivesEvents(t *testing.T) {
 	data, marshalErr := json.Marshal(evt)
 	require.NoError(t, marshalErr)
 
-	// Publish to the tenant's channel
-	channel := ChannelForTenant(evt.TenantID)
+	// Publish on the env-scoped channel that the listener actually subscribes to.
+	channel := events.TenantEventsChannel("staging")
 
 	publishCount := mr.Publish(channel, string(data))
 	require.Greater(t, publishCount, 0, "expected at least one subscriber to receive the message")
@@ -220,7 +479,7 @@ func TestTenantEventListener_ReceivesEvents(t *testing.T) {
 }
 
 func TestTenantEventListener_ParseError(t *testing.T) {
-	t.Parallel()
+	setEnv(t, "staging")
 
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
@@ -246,8 +505,8 @@ func TestTenantEventListener_ParseError(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	// Publish invalid JSON — should not crash, should be skipped
-	channel := ChannelForTenant("t-bad")
+	// Publish invalid JSON on the env-scoped channel — should not crash, should be skipped
+	channel := events.TenantEventsChannel("staging")
 
 	publishCount := mr.Publish(channel, "{invalid json")
 	require.Greater(t, publishCount, 0, "expected at least one subscriber")
@@ -267,7 +526,7 @@ func TestTenantEventListener_ParseError(t *testing.T) {
 }
 
 func TestTenantEventListener_HandlerError(t *testing.T) {
-	t.Parallel()
+	setEnv(t, "production")
 
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
@@ -295,7 +554,7 @@ func TestTenantEventListener_HandlerError(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	// Publish a valid event
+	// Publish a valid event on the env-scoped channel
 	evt := TenantLifecycleEvent{
 		EventID:     "evt-002",
 		EventType:   EventTenantActivated,
@@ -308,7 +567,7 @@ func TestTenantEventListener_HandlerError(t *testing.T) {
 	data, marshalErr := json.Marshal(evt)
 	require.NoError(t, marshalErr)
 
-	channel := ChannelForTenant(evt.TenantID)
+	channel := events.TenantEventsChannel("production")
 
 	publishCount := mr.Publish(channel, string(data))
 	require.Greater(t, publishCount, 0, "expected at least one subscriber")

--- a/commons/tenant-manager/event/types.go
+++ b/commons/tenant-manager/event/types.go
@@ -41,7 +41,14 @@ const (
 	// ChannelPrefix is the base prefix for all tenant event channels.
 	ChannelPrefix = "tenant-events"
 
-	// SubscriptionPattern is the glob pattern to subscribe to all tenant event channels.
+	// SubscriptionPattern is the legacy glob pattern that subscribed to every
+	// tenant event channel regardless of environment.
+	//
+	// Deprecated: The listener no longer uses this pattern. Subscribing to it
+	// directly leaks events across environments (staging <-> production sharing a
+	// Valkey cluster will cross-deliver). Use
+	// events.TenantEventsChannel(commons.CurrentEnv()) instead. Retained only
+	// for backward compatibility with downstream callers and existing tests.
 	SubscriptionPattern = "tenant-events:*"
 )
 


### PR DESCRIPTION
## Summary

- Backports the env-scoping fix from v5.4.0 + v5.4.1 (originally landed in v5.1.2 via PR #496) onto the v4 maintenance line.
- Adds `commons.CurrentEnv()` / `commons.MustCurrentEnv()` and `events.TenantEventsChannel(env)` helpers — minimum surface required for the listener fix.
- `TenantEventListener.Start()` now subscribes to the env-scoped channel `tenant-events:{env}:` instead of the wildcard `tenant-events:*`, closing the cross-environment leak.

## Why a v4.6.x patch instead of asking apps to bump to v5

Apps still pinned to `lib-commons/v4` (tracer at v4.6.1, plugin-fees at v4.6.0) cannot move to v5.x without a major-version migration: the import path changes from `github.com/LerianStudio/lib-commons/v4/...` to `.../v5/...` and there are breaking API changes (security framework simplification, rate-limit semantics, etc.). Forcing a v5 bump just to pick up this fix is not viable on the current timeline. This patch lands the **minimum** surface required to close the leak on the v4 line.

## What's included

### Added (backport from v5.4.0)
- `commons.CurrentEnv()` / `commons.MustCurrentEnv()` — reads `ENVIRONMENT_NAME` (preferred) or `ENV_NAME` (also accepted), validates value is `staging` or `production`.
- `commons.EnvStaging`, `commons.EnvProduction` constants.
- `events.TenantEventsChannel(env)` — returns `"tenant-events:{env}:"`.
- `events.TenantEventsChannelPrefix` constant.

### Fixed (backport from v5.4.1)
- Multi-tenant event listener (`commons/tenant-manager/event.TenantEventListener`) now subscribes ONLY to the env-scoped channel `tenant-events:{env}:` (resolved via `commons.CurrentEnv()`). The previous wildcard `PSubscribe("tenant-events:*")` leaked events across environments. `Start()` now requires `ENVIRONMENT_NAME` (or `ENV_NAME`) to be set in the multi-tenant consumer process.

### Deprecated
- `event.SubscriptionPattern` (`"tenant-events:*"`) — retained for backward compatibility (public symbol, not deleted) but no longer used by the listener. Use `events.TenantEventsChannel(commons.CurrentEnv())` instead. Subscribing to the legacy wildcard leaks events across environments.

## What's NOT included (left in v5.x line)

- Security framework simplification (`security_override.go` removal, `SecurityTier`, `CheckSecurityRule`, etc.)
- Rate limit env var changes (`RATE_LIMIT_ENABLED` default flip, `ALLOW_RATELIMIT_DISABLED` removal)
- Other v4.6.2 — v5.4.x improvements

Apps that want any of the above must migrate to `lib-commons/v5`.

## Operator action required

**Before bumping to v4.6.2, multi-tenant consumer pods MUST set `ENVIRONMENT_NAME` (or `ENV_NAME`) to `staging` or `production`. Otherwise `TenantEventListener.Start()` returns an error and the process fails to boot.**

**Single-tenant apps are unaffected** — wiring `NewTenantEventListener` IS the activation of multi-tenant mode. Apps that never wire it skip the env-var requirement entirely.

## Related PRs

- v5.1.2 backport (origin of this patch's structure): https://github.com/LerianStudio/lib-commons/pull/496
- v5.4.0 (env helpers + `TenantEventsChannel`): https://github.com/LerianStudio/lib-commons/pull/493
- v5.4.1 (listener env-scoped Subscribe): https://github.com/LerianStudio/lib-commons/pull/495

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l` on all touched files — clean
- [x] `go test -tags=unit -count=1 -short ./...` — 5775/5775 pass
- [x] Targeted tests on backport packages — 37/37 pass
- [x] New `TestTenantEventListener_Start_MissingEnvFailsFast` asserts error mentions BOTH `ENVIRONMENT_NAME` AND `ENV_NAME`
- [x] `TestTenantEventListener_SubscribesToStagingChannel` / `...ToProductionChannel` verify env-scoped subscription
- [x] `TestTenantEventListener_IgnoresLegacyPerTenantChannel` / `...IgnoresOtherEnvChannel` verify cross-env isolation
- [x] golangci-lint clean on all backport files (commons/events, commons/tenant-manager/event)

Test count delta on v4 line:
- `commons/tenant-manager/event/listener_test.go`: 13 → 18 tests (+5)
- `commons/env_test.go`: new — 4 tests (TestCurrentEnv has 16 sub-cases)
- `commons/events/tenant_events_test.go`: new — 2 tests

## After merge

Tag `v4.6.2` on the merge commit. Do NOT merge into `develop` / `main` — this is a v4 maintenance-only release.
