### PR TITLE
fix: remove wildcard retrocompat from tenant manager channel subscription

### DIFF
--- a/commons/tenant-manager/event/types.go
+++ b/commons/tenant-manager/event/types.go
@@ -39,17 +39,14 @@ const (
 // Channel constants for Valkey Streams pub/sub.
 const (
 	// ChannelPrefix is the base prefix for all tenant event channels.
-	ChannelPrefix = "tenant-events"
-
-	// SubscriptionPattern is the glob pattern to subscribe to all tenant event channels.
 	//
-	// Deprecated: The TenantEventListener no longer references this pattern; it
-	// subscribes to the env-scoped channel returned by
-	// commons/events.TenantEventsChannel(commons.CurrentEnv()) instead. The
-	// previous wildcard PSubscribe leaked events across environments. This
-	// constant is retained only for custom subscriber implementations outside
-	// the bundled listener; new code MUST NOT use it.
-	SubscriptionPattern = "tenant-events:*"
+	// Subscribers MUST subscribe to the env-scoped channel returned by
+	// commons/events.TenantEventsChannel(commons.CurrentEnv()) — ENV_NAME (or
+	// ENVIRONMENT_NAME) is mandatory. The retrocompat wildcard subscription
+	// ("tenant-events:*") has been removed: it leaked events across
+	// environments (staging events reaching production and vice versa). All
+	// services have migrated to the env-scoped channel.
+	ChannelPrefix = "tenant-events"
 )
 
 // TenantLifecycleEvent is the envelope for all tenant lifecycle events.

--- a/commons/tenant-manager/event/types_test.go
+++ b/commons/tenant-manager/event/types_test.go
@@ -149,12 +149,6 @@ func TestChannelForTenant(t *testing.T) {
 	}
 }
 
-func TestSubscriptionPattern(t *testing.T) {
-	t.Parallel()
-
-	assert.Equal(t, "tenant-events:*", SubscriptionPattern)
-}
-
 func TestChannelPrefix(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Removes the retrocompat wildcard subscription pattern (`tenant-events:*`) from the Tenant Manager event package. **ENV_NAME (or ENVIRONMENT_NAME) is now mandatory** for any tenant-events subscriber.

## Why

The wildcard `PSubscribe("tenant-events:*")` matched **all** env-scoped channels, so a subscriber could receive events from any environment. In practice this caused **staging events reaching production and vice versa** — a cross-environment isolation bug.

The bundled `TenantEventListener` already migrated to the env-scoped channel (`events.TenantEventsChannel(commons.CurrentEnv())`, e.g. `tenant-events:staging:`). The wildcard constant was only kept as deprecated retrocompat while downstream services migrated. **All services have now migrated**, so this PR finalizes the cleanup by removing the leftover wildcard.

## What changed

- Removed the deprecated `SubscriptionPattern = "tenant-events:*"` constant from `commons/tenant-manager/event/types.go`.
- Updated the `ChannelPrefix` doc comment to state that env-scoped subscription is required and explain why the wildcard was removed.
- Removed the now-obsolete `TestSubscriptionPattern` test.

## ENV_NAME is mandatory (fail-fast)

`CurrentEnv()` already enforces this and returns a descriptive error when `ENVIRONMENT_NAME`/`ENV_NAME` is unset/empty/invalid; `TenantEventListener.Start()` propagates that error and refuses to subscribe. With the wildcard gone there is no fallback path — a service without ENV_NAME fails at subscription time instead of silently subscribing across environments.

## Verification

- `go build ./commons/tenant-manager/... ./commons/events/...` — OK
- `go test -tags unit ./commons/tenant-manager/event/... ./commons/events/...` — PASS

Requested-by: @qnen