### PR TITLE
fix(outbox): log publish failures and add optional OnInvalid/OnFailed lifecycle callbacks

### DIFF
--- a/commons/outbox/config.go
+++ b/commons/outbox/config.go
@@ -1,6 +1,7 @@
 package outbox
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -56,6 +57,14 @@ type DispatcherConfig struct {
 	MaxTrackedListPendingFailureTenants int
 	// MeterProvider overrides the default global meter provider when set.
 	MeterProvider metric.MeterProvider
+	// OnInvalid is an optional best-effort callback invoked when an event
+	// transitions to INVALID (non-retryable error or max dispatch attempts
+	// exhausted). It must not panic; panics and errors are logged and swallowed.
+	OnInvalid func(ctx context.Context, event *OutboxEvent, err error)
+	// OnFailed is an optional best-effort callback invoked when an event fails
+	// a dispatch attempt but remains retryable (marked FAILED). It must not
+	// panic; panics and errors are logged and swallowed.
+	OnFailed func(ctx context.Context, event *OutboxEvent, err error)
 }
 
 // DefaultDispatcherConfig returns the baseline dispatcher configuration.
@@ -282,6 +291,22 @@ func WithMaxTrackedListPendingFailureTenants(maxTenants int) DispatcherOption {
 		if maxTenants > 0 {
 			dispatcher.cfg.MaxTrackedListPendingFailureTenants = maxTenants
 		}
+	}
+}
+
+// WithOnInvalid sets a best-effort callback invoked when an event transitions to INVALID.
+// Passing nil disables the callback.
+func WithOnInvalid(fn func(ctx context.Context, event *OutboxEvent, err error)) DispatcherOption {
+	return func(dispatcher *Dispatcher) {
+		dispatcher.cfg.OnInvalid = fn
+	}
+}
+
+// WithOnFailed sets a best-effort callback invoked when an event is marked FAILED but remains retryable.
+// Passing nil disables the callback.
+func WithOnFailed(fn func(ctx context.Context, event *OutboxEvent, err error)) DispatcherOption {
+	return func(dispatcher *Dispatcher) {
+		dispatcher.cfg.OnFailed = fn
 	}
 }
 

--- a/commons/outbox/dispatcher.go
+++ b/commons/outbox/dispatcher.go
@@ -922,17 +922,102 @@ func (dispatcher *Dispatcher) handlePublishError(
 	event *OutboxEvent,
 	err error,
 ) {
+	// Always surface the publish failure before mutating event state so that
+	// transitions to FAILED/INVALID are observable in logs.
+	logger.Log(
+		ctx,
+		libLog.LevelWarn,
+		"outbox event publish failed",
+		libLog.String("event_id", event.ID.String()),
+		libLog.String("event_type", event.EventType),
+		libLog.Err(err),
+	)
+
 	if dispatcher.isNonRetryableError(err) {
+		// Non-retryable errors send the event straight to INVALID; log at ERROR.
+		logger.Log(
+			ctx,
+			libLog.LevelError,
+			"outbox event is non-retryable; marking invalid",
+			libLog.String("event_id", event.ID.String()),
+			libLog.String("event_type", event.EventType),
+			libLog.Err(err),
+		)
+
 		if markErr := dispatcher.repo.MarkInvalid(ctx, event.ID, sanitizeErrorForStorage(err)); markErr != nil {
 			logger.Log(ctx, libLog.LevelError, "failed to mark outbox invalid", libLog.String("error", sanitizeErrorForStorage(markErr)))
 		}
+
+		dispatcher.invokeOnInvalid(ctx, event, err)
 
 		return
 	}
 
 	if markErr := dispatcher.repo.MarkFailed(ctx, event.ID, sanitizeErrorForStorage(err), dispatcher.cfg.MaxDispatchAttempts); markErr != nil {
 		logger.Log(ctx, libLog.LevelError, "failed to mark outbox failed", libLog.String("error", sanitizeErrorForStorage(markErr)))
+
+		return
 	}
+
+	// MarkFailed transitions FAILED->INVALID internally once attempts reach
+	// MaxDispatchAttempts. Mirror that decision here so the INVALID callback
+	// fires when this attempt exhausts the budget; otherwise treat as a
+	// retryable failure.
+	if event.Attempts+1 >= dispatcher.cfg.MaxDispatchAttempts {
+		dispatcher.invokeOnInvalid(ctx, event, err)
+
+		return
+	}
+
+	dispatcher.invokeOnFailed(ctx, event, err)
+}
+
+// invokeOnInvalid runs the optional OnInvalid callback best-effort, swallowing panics and errors.
+func (dispatcher *Dispatcher) invokeOnInvalid(ctx context.Context, event *OutboxEvent, err error) {
+	if dispatcher.cfg.OnInvalid == nil {
+		return
+	}
+
+	dispatcher.safeInvokeLifecycle(ctx, "OnInvalid", dispatcher.cfg.OnInvalid, event, err)
+}
+
+// invokeOnFailed runs the optional OnFailed callback best-effort, swallowing panics and errors.
+func (dispatcher *Dispatcher) invokeOnFailed(ctx context.Context, event *OutboxEvent, err error) {
+	if dispatcher.cfg.OnFailed == nil {
+		return
+	}
+
+	dispatcher.safeInvokeLifecycle(ctx, "OnFailed", dispatcher.cfg.OnFailed, event, err)
+}
+
+// safeInvokeLifecycle invokes a lifecycle callback, recovering from panics and
+// logging at WARN so a misbehaving callback never breaks the dispatch loop.
+func (dispatcher *Dispatcher) safeInvokeLifecycle(
+	ctx context.Context,
+	name string,
+	fn func(ctx context.Context, event *OutboxEvent, err error),
+	event *OutboxEvent,
+	err error,
+) {
+	logger := dispatcher.logger
+	if nilcheck.Interface(logger) {
+		logger = libLog.NewNop()
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Log(
+				ctx,
+				libLog.LevelWarn,
+				"outbox lifecycle callback panicked",
+				libLog.String("callback", name),
+				libLog.String("event_id", event.ID.String()),
+				libLog.String("panic", fmt.Sprintf("%v", r)),
+			)
+		}
+	}()
+
+	fn(ctx, event, err)
 }
 
 func (dispatcher *Dispatcher) isNonRetryableError(err error) bool {

--- a/commons/outbox/dispatcher.go
+++ b/commons/outbox/dispatcher.go
@@ -946,8 +946,13 @@ func (dispatcher *Dispatcher) handlePublishError(
 
 		if markErr := dispatcher.repo.MarkInvalid(ctx, event.ID, sanitizeErrorForStorage(err)); markErr != nil {
 			logger.Log(ctx, libLog.LevelError, "failed to mark outbox invalid", libLog.String("error", sanitizeErrorForStorage(markErr)))
+
+			return
 		}
 
+		// Only invoke the OnInvalid callback after the event has been durably
+		// persisted as INVALID; otherwise we would emit a callback for an event
+		// that was not actually transitioned in storage.
 		dispatcher.invokeOnInvalid(ctx, event, err)
 
 		return

--- a/commons/outbox/dispatcher_callbacks_test.go
+++ b/commons/outbox/dispatcher_callbacks_test.go
@@ -1,0 +1,295 @@
+//go:build unit
+
+package outbox
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	libLog "github.com/LerianStudio/lib-observability/log"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+type logEntry struct {
+	level  libLog.Level
+	msg    string
+	fields []libLog.Field
+}
+
+// recordingLogger captures emitted log entries for assertions.
+type recordingLogger struct {
+	mu      sync.Mutex
+	entries []logEntry
+}
+
+func (l *recordingLogger) Log(_ context.Context, level libLog.Level, msg string, fields ...libLog.Field) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, logEntry{level: level, msg: msg, fields: fields})
+}
+
+func (l *recordingLogger) With(...libLog.Field) libLog.Logger { return l }
+func (l *recordingLogger) WithGroup(string) libLog.Logger     { return l }
+func (l *recordingLogger) Enabled(libLog.Level) bool          { return true }
+func (l *recordingLogger) Sync(context.Context) error         { return nil }
+
+func (l *recordingLogger) hasLevel(level libLog.Level) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, e := range l.entries {
+		if e.level == level {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestDispatcher_HandlePublishError_NilCallbacksDoNotBreak(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	eventID := uuid.New()
+	repo.pending = []*OutboxEvent{{ID: eventID, EventType: "payment.created", Payload: []byte("ok")}}
+
+	handlers := NewHandlerRegistry()
+	require.NoError(t, handlers.Register("payment.created", func(context.Context, *OutboxEvent) error {
+		return errors.New("temporary broker outage")
+	}))
+
+	dispatcher, err := NewDispatcher(repo, handlers, nil, noop.NewTracerProvider().Tracer("test"), WithPublishMaxAttempts(1))
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_ = dispatcher.DispatchOnce(context.Background())
+	})
+	require.Equal(t, []uuid.UUID{eventID}, repo.markedFail)
+}
+
+func TestDispatcher_HandlePublishError_CallbackPanicIsSwallowed(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	eventID := uuid.New()
+	repo.pending = []*OutboxEvent{{ID: eventID, EventType: "payment.created", Payload: []byte("ok")}}
+
+	handlers := NewHandlerRegistry()
+	require.NoError(t, handlers.Register("payment.created", func(context.Context, *OutboxEvent) error {
+		return errors.New("temporary broker outage")
+	}))
+
+	logger := &recordingLogger{}
+	dispatcher, err := NewDispatcher(
+		repo,
+		handlers,
+		logger,
+		noop.NewTracerProvider().Tracer("test"),
+		WithPublishMaxAttempts(1),
+		WithMaxDispatchAttempts(10),
+		WithOnFailed(func(context.Context, *OutboxEvent, error) {
+			panic("boom")
+		}),
+	)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_ = dispatcher.DispatchOnce(context.Background())
+	})
+	require.True(t, logger.hasLevel(libLog.LevelWarn))
+}
+
+func TestDispatcher_HandlePublishError_LogsWarnOnFailure(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	eventID := uuid.New()
+	repo.pending = []*OutboxEvent{{ID: eventID, EventType: "payment.created", Payload: []byte("ok")}}
+
+	handlers := NewHandlerRegistry()
+	require.NoError(t, handlers.Register("payment.created", func(context.Context, *OutboxEvent) error {
+		return errors.New("temporary broker outage")
+	}))
+
+	logger := &recordingLogger{}
+	dispatcher, err := NewDispatcher(
+		repo,
+		handlers,
+		logger,
+		noop.NewTracerProvider().Tracer("test"),
+		WithPublishMaxAttempts(1),
+		WithMaxDispatchAttempts(10),
+	)
+	require.NoError(t, err)
+
+	_ = dispatcher.DispatchOnce(context.Background())
+
+	logger.mu.Lock()
+	defer logger.mu.Unlock()
+
+	var found bool
+	for _, e := range logger.entries {
+		if e.level != libLog.LevelWarn || e.msg != "outbox event publish failed" {
+			continue
+		}
+
+		var sawEventID, sawEventType bool
+		for _, f := range e.fields {
+			if f.Key == "event_id" && f.Value == eventID.String() {
+				sawEventID = true
+			}
+			if f.Key == "event_type" && f.Value == "payment.created" {
+				sawEventType = true
+			}
+		}
+		if sawEventID && sawEventType {
+			found = true
+		}
+	}
+	require.True(t, found, "expected WARN log with event_id and event_type")
+}
+
+func TestDispatcher_HandlePublishError_OnInvalidCalledOnMaxAttempts(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	eventID := uuid.New()
+	// Attempts already at max-1 so this attempt (Attempts+1) reaches MaxDispatchAttempts.
+	repo.pending = []*OutboxEvent{{ID: eventID, EventType: "payment.created", Payload: []byte("ok"), Attempts: 9}}
+
+	handlers := NewHandlerRegistry()
+	require.NoError(t, handlers.Register("payment.created", func(context.Context, *OutboxEvent) error {
+		return errors.New("temporary broker outage")
+	}))
+
+	var (
+		mu             sync.Mutex
+		onInvalidCalls []uuid.UUID
+		onFailedCalls  []uuid.UUID
+	)
+
+	dispatcher, err := NewDispatcher(
+		repo,
+		handlers,
+		nil,
+		noop.NewTracerProvider().Tracer("test"),
+		WithPublishMaxAttempts(1),
+		WithMaxDispatchAttempts(10),
+		WithOnInvalid(func(_ context.Context, event *OutboxEvent, _ error) {
+			mu.Lock()
+			onInvalidCalls = append(onInvalidCalls, event.ID)
+			mu.Unlock()
+		}),
+		WithOnFailed(func(_ context.Context, event *OutboxEvent, _ error) {
+			mu.Lock()
+			onFailedCalls = append(onFailedCalls, event.ID)
+			mu.Unlock()
+		}),
+	)
+	require.NoError(t, err)
+
+	_ = dispatcher.DispatchOnce(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []uuid.UUID{eventID}, onInvalidCalls)
+	require.Empty(t, onFailedCalls)
+}
+
+func TestDispatcher_HandlePublishError_OnInvalidCalledOnNonRetryable(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	eventID := uuid.New()
+	repo.pending = []*OutboxEvent{{ID: eventID, EventType: "payment.created", Payload: []byte("ok")}}
+
+	nonRetryable := errors.New("validation failed")
+	handlers := NewHandlerRegistry()
+	require.NoError(t, handlers.Register("payment.created", func(context.Context, *OutboxEvent) error {
+		return nonRetryable
+	}))
+
+	var (
+		mu             sync.Mutex
+		onInvalidCalls []uuid.UUID
+		onFailedCalls  []uuid.UUID
+	)
+
+	dispatcher, err := NewDispatcher(
+		repo,
+		handlers,
+		nil,
+		noop.NewTracerProvider().Tracer("test"),
+		WithPublishMaxAttempts(1),
+		WithRetryClassifier(RetryClassifierFunc(func(err error) bool {
+			return errors.Is(err, nonRetryable)
+		})),
+		WithOnInvalid(func(_ context.Context, event *OutboxEvent, _ error) {
+			mu.Lock()
+			onInvalidCalls = append(onInvalidCalls, event.ID)
+			mu.Unlock()
+		}),
+		WithOnFailed(func(_ context.Context, event *OutboxEvent, _ error) {
+			mu.Lock()
+			onFailedCalls = append(onFailedCalls, event.ID)
+			mu.Unlock()
+		}),
+	)
+	require.NoError(t, err)
+
+	_ = dispatcher.DispatchOnce(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []uuid.UUID{eventID}, onInvalidCalls)
+	require.Empty(t, onFailedCalls)
+}
+
+func TestDispatcher_HandlePublishError_OnFailedCalledOnIntermediateFailure(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	eventID := uuid.New()
+	repo.pending = []*OutboxEvent{{ID: eventID, EventType: "payment.created", Payload: []byte("ok"), Attempts: 0}}
+
+	handlers := NewHandlerRegistry()
+	require.NoError(t, handlers.Register("payment.created", func(context.Context, *OutboxEvent) error {
+		return errors.New("temporary broker outage")
+	}))
+
+	var (
+		mu             sync.Mutex
+		onInvalidCalls []uuid.UUID
+		onFailedCalls  []uuid.UUID
+	)
+
+	dispatcher, err := NewDispatcher(
+		repo,
+		handlers,
+		nil,
+		noop.NewTracerProvider().Tracer("test"),
+		WithPublishMaxAttempts(1),
+		WithMaxDispatchAttempts(10),
+		WithOnInvalid(func(_ context.Context, event *OutboxEvent, _ error) {
+			mu.Lock()
+			onInvalidCalls = append(onInvalidCalls, event.ID)
+			mu.Unlock()
+		}),
+		WithOnFailed(func(_ context.Context, event *OutboxEvent, _ error) {
+			mu.Lock()
+			onFailedCalls = append(onFailedCalls, event.ID)
+			mu.Unlock()
+		}),
+	)
+	require.NoError(t, err)
+
+	_ = dispatcher.DispatchOnce(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []uuid.UUID{eventID}, onFailedCalls)
+	require.Empty(t, onInvalidCalls)
+}


### PR DESCRIPTION
## Summary

Closes two gaps in the outbox dispatcher's publish-failure path.

### Change 1 — logging in `handlePublishError`
- Emit a `WARN` log with `event_id`, `event_type`, and `err` **before** any `MarkFailed`/`MarkInvalid`, so all FAILED/INVALID transitions are observable.
- When the error is non-retryable (event goes straight to INVALID), additionally log at `ERROR`.
- The MaxDispatchAttempts→INVALID transition is covered by the upfront WARN.

### Change 2 — optional lifecycle callbacks
- New `DispatcherConfig` fields `OnInvalid` and `OnFailed`.
- New options `WithOnInvalid` / `WithOnFailed`.
- Best-effort private helpers `invokeOnInvalid`/`invokeOnFailed` (+ `safeInvokeLifecycle`): nil callback is a no-op; panics are recovered and logged at WARN, never breaking the dispatch loop.
- `OnInvalid` fires when the event reaches INVALID — both via non-retryable classification and when `MarkFailed` exhausts `MaxDispatchAttempts` (`Attempts+1 >= MaxDispatchAttempts`, mirroring the repository's internal FAILED→INVALID transition). `OnFailed` fires for intermediate retryable failures.

## Tests
Added `dispatcher_callbacks_test.go` covering:
- nil callbacks don't break dispatch
- callback panic is swallowed (logged WARN)
- WARN log emitted on failure with event_id/event_type
- OnInvalid called when max attempts reached
- OnInvalid called on non-retryable error
- OnFailed called on intermediate failure

`go test -tags unit ./commons/outbox/`, `go vet`, and `golangci-lint run` all pass.

Requested-by: @qnen