### PR TITLE
feat(net): add Huma OpenAPI wrapper and RFC 9457 problem model

### DIFF
--- a/commons/net/http/openapi/openapi.go
+++ b/commons/net/http/openapi/openapi.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 
 	libLog "github.com/LerianStudio/lib-observability/log"
 	"github.com/danielgtaylor/huma/v2"
@@ -138,14 +139,19 @@ func DeclareBearerAuth(api huma.API) {
 // deliberately OFF the auth/tenant chain (public-within-the-gate). Callers MUST
 // gate this on their Swagger.Enabled flag; it is never registered when the flag
 // is false. If the spec fails to render the routes are skipped and the failure
-// is logged. Nil-safe on api.
+// is logged. Nil-safe: a nil app or api is a no-op, and a nil logger falls back
+// to a no-op logger so a render failure never panics.
 //
 // title is the docs page <title>; the Scalar data-url points at the
 // prefix-scoped /openapi.json route. Services share this helper; the prefix and
 // title diverge per service.
 func ServeSpec(app *fiber.App, api huma.API, logger libLog.Logger, prefix, title string) {
-	if api == nil {
+	if app == nil || api == nil {
 		return
+	}
+
+	if logger == nil {
+		logger = libLog.NewNop()
 	}
 
 	specYAML, err := api.OpenAPI().YAML()
@@ -189,6 +195,9 @@ func scalarCSPMiddleware() fiber.Handler {
 }
 
 // docsHTML renders the Scalar docs page bytes for the given title and spec URL.
+// Both values are HTML-escaped before interpolation so a title or prefix
+// carrying HTML/attribute-breaking characters cannot inject markup or script
+// into the /docs page.
 func docsHTML(title, specURL string) []byte {
-	return fmt.Appendf(nil, docsHTMLTemplate, title, specURL)
+	return fmt.Appendf(nil, docsHTMLTemplate, html.EscapeString(title), html.EscapeString(specURL))
 }

--- a/commons/net/http/openapi/openapi.go
+++ b/commons/net/http/openapi/openapi.go
@@ -1,0 +1,194 @@
+// Package openapi adapts an existing Fiber v2 application into a configured
+// Huma v2 API that emits OpenAPI 3.1 metadata. It is a thin adapter only: it
+// configures the document metadata, suppresses Huma's auto-mounted spec/docs
+// routes, binds the API to a Fiber group via the Fiber v2 adapter, and serves
+// the spec + Scalar docs on explicit, caller-gated routes.
+//
+// It applies NO error policy. Error policy is the org-wide RFC 9457 model in
+// commons/net/http/problem, installed by the consumer's bootstrap via
+// problem.Install(). This package deliberately does NOT import problem: the
+// binding layer must not depend on the error model. Until a consumer calls
+// problem.Install(), Huma emits its native RFC 9457 application/problem+json
+// error model, which handlers select via the package-level huma.ErrorNNN
+// constructors.
+//
+// This package is platform glue shared by every Lerian service; it must not
+// import any bounded-context package.
+package openapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	libLog "github.com/LerianStudio/lib-observability/log"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humafiber"
+	"github.com/gofiber/fiber/v2"
+)
+
+// scalarCSP relaxes the strict global CSP for the Scalar docs page so the
+// Scalar bundle and its assets load from the jsdelivr CDN. It is applied
+// per-route by scalarCSPMiddleware; the global strict CSP is unaffected
+// elsewhere.
+const scalarCSP = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https://cdn.jsdelivr.net; font-src 'self' data: https://cdn.jsdelivr.net; connect-src 'self'"
+
+// docsHTMLTemplate is a minimal, dependency-free docs page that renders a Huma
+// spec via Scalar loaded from a CDN <script>. The title and the spec URL are
+// substituted per service (%[1]s = title, %[2]s = spec URL). No Go dependency is
+// added for the docs UI.
+const docsHTMLTemplate = `<!doctype html>
+<html>
+  <head>
+    <title>%[1]s</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <script id="api-reference" data-url="%[2]s"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>`
+
+// Config carries the OpenAPI metadata for the generated API. It is intentionally
+// transport-agnostic so callers in bootstrap supply values from service config.
+type Config struct {
+	// Title is the API title surfaced in the OpenAPI Info object.
+	Title string
+	// Version is the API document version surfaced in the OpenAPI Info object.
+	Version string
+	// Description is an optional long-form API description.
+	Description string
+	// Servers lists the server URLs advertised in the spec.
+	Servers []string
+}
+
+// New wraps an existing Fiber app/group with a Huma v2 API that emits OpenAPI
+// 3.1. It starts from huma.DefaultConfig, configures the Info metadata and
+// servers, then clears auto-mount + transformers and applies no error policy
+// (native RFC 9457 until the consumer calls problem.Install). Serving the
+// spec/docs is the caller's concern (see ServeSpec). Operations are registered
+// by callers, not here.
+func New(app *fiber.App, group fiber.Router, cfg Config) huma.API {
+	humaConfig := huma.DefaultConfig(cfg.Title, cfg.Version)
+	humaConfig.Info.Description = cfg.Description
+
+	// DefaultConfig installs a SchemaLinkTransformer that, by reflection,
+	// rebuilds every response body into a new struct carrying a `$schema` field
+	// plus copies of the original's exported fields. That bypasses custom
+	// json.Marshaler implementations and leaks an internal schema URL into every
+	// response body. Strip it so bodies serialize exactly as written.
+	humaConfig.Transformers = nil
+	humaConfig.OnAddOperation = nil
+	humaConfig.CreateHooks = nil
+	humaConfig.SchemasPath = ""
+
+	// DefaultConfig leaves OpenAPIPath="/openapi" and DocsPath="/docs", which
+	// makes humafiber.NewV2WithGroup auto-mount /openapi.json, /openapi.yaml,
+	// and /docs on the supplied group at construction time — un-gated and, since
+	// an API commonly binds to the app root, reachable in production. Clearing
+	// both paths disables that auto-mount: the wrapper registers NO HTTP routes,
+	// so it never silently exposes the spec. Serving spec/docs becomes an
+	// explicit, gated bootstrap concern, keeping this shared wrapper free of
+	// exposure policy. Clearing the paths suppresses route registration only;
+	// api.OpenAPI() stays fully populated.
+	humaConfig.OpenAPIPath = ""
+	humaConfig.DocsPath = ""
+
+	if len(cfg.Servers) > 0 {
+		servers := make([]*huma.Server, 0, len(cfg.Servers))
+		for _, url := range cfg.Servers {
+			servers = append(servers, &huma.Server{URL: url})
+		}
+
+		humaConfig.Servers = servers
+	}
+
+	return humafiber.NewV2WithGroup(app, group, humaConfig)
+}
+
+// DeclareBearerAuth registers the BearerAuth HTTP bearer/JWT security scheme in
+// the API's components so per-operation Security:[{"BearerAuth":{}}] references
+// resolve in the generated spec instead of dangling. It carries zero service
+// content, so it lives in this shared adapter; services declare the same scheme.
+// Declared once on the shared API; idempotent (re-declaring the same scheme is a
+// no-op overwrite). Nil-safe.
+func DeclareBearerAuth(api huma.API) {
+	if api == nil {
+		return
+	}
+
+	components := api.OpenAPI().Components
+	if components.SecuritySchemes == nil {
+		components.SecuritySchemes = map[string]*huma.SecurityScheme{}
+	}
+
+	components.SecuritySchemes["BearerAuth"] = &huma.SecurityScheme{
+		Type:         "http",
+		Scheme:       "bearer",
+		BearerFormat: "JWT",
+		Description:  "JWT bearer token issued by the identity provider.",
+	}
+}
+
+// ServeSpec mounts the Huma OpenAPI spec + Scalar docs under prefix:
+// {prefix}/openapi.json, {prefix}/openapi.yaml, and {prefix}/docs. The Huma
+// spec is immutable after operation registration, so the JSON/YAML bytes are
+// snapshotted once here rather than marshaled per request. These routes are
+// deliberately OFF the auth/tenant chain (public-within-the-gate). Callers MUST
+// gate this on their Swagger.Enabled flag; it is never registered when the flag
+// is false. If the spec fails to render the routes are skipped and the failure
+// is logged. Nil-safe on api.
+//
+// title is the docs page <title>; the Scalar data-url points at the
+// prefix-scoped /openapi.json route. Services share this helper; the prefix and
+// title diverge per service.
+func ServeSpec(app *fiber.App, api huma.API, logger libLog.Logger, prefix, title string) {
+	if api == nil {
+		return
+	}
+
+	specYAML, err := api.OpenAPI().YAML()
+	if err != nil {
+		logger.Log(context.Background(), libLog.LevelError, "failed to render Huma spec yaml", libLog.Err(err))
+		return
+	}
+
+	specJSON, err := json.Marshal(api.OpenAPI())
+	if err != nil {
+		logger.Log(context.Background(), libLog.LevelError, "failed to marshal Huma spec json", libLog.Err(err))
+		return
+	}
+
+	specURL := prefix + "/openapi.json"
+	docs := docsHTML(title, specURL)
+
+	group := app.Group(prefix)
+	group.Get("/openapi.json", func(c *fiber.Ctx) error {
+		c.Type("json")
+		return c.Send(specJSON)
+	})
+	group.Get("/openapi.yaml", func(c *fiber.Ctx) error {
+		c.Set(fiber.HeaderContentType, "application/yaml; charset=utf-8")
+		return c.Send(specYAML)
+	})
+	group.Get("/docs", scalarCSPMiddleware(), func(c *fiber.Ctx) error {
+		c.Type("html")
+		return c.Send(docs)
+	})
+}
+
+// scalarCSPMiddleware overrides the global strict CSP for the Scalar docs page
+// so the Scalar bundle can load from the jsdelivr CDN. Applied only to that
+// route; the global strict CSP is unaffected elsewhere.
+func scalarCSPMiddleware() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set("Content-Security-Policy", scalarCSP)
+		return c.Next()
+	}
+}
+
+// docsHTML renders the Scalar docs page bytes for the given title and spec URL.
+func docsHTML(title, specURL string) []byte {
+	return fmt.Appendf(nil, docsHTMLTemplate, title, specURL)
+}

--- a/commons/net/http/openapi/openapi_test.go
+++ b/commons/net/http/openapi/openapi_test.go
@@ -1,0 +1,368 @@
+//go:build unit
+
+package openapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/LerianStudio/lib-commons/v5/commons/net/http/problem"
+	libLog "github.com/LerianStudio/lib-observability/log"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// echoInput / echoOutput back a throwaway operation used to force schema and
+// route generation without pulling in any bounded-context type.
+type echoInput struct {
+	Body struct {
+		Name string `json:"name"`
+	}
+}
+
+type echoOutput struct {
+	Body struct {
+		Name string `json:"name"`
+	}
+}
+
+func registerEcho(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "echo",
+		Method:      http.MethodPost,
+		Path:        "/echo",
+	}, func(_ context.Context, in *echoInput) (*echoOutput, error) {
+		out := &echoOutput{}
+		out.Body.Name = in.Body.Name
+		return out, nil
+	})
+}
+
+func testConfig() Config {
+	return Config{
+		Title:       "Test API",
+		Version:     "1.0.0",
+		Description: "test description",
+		Servers:     []string{"https://api.example.com", "https://api.staging.example.com"},
+	}
+}
+
+// doReq runs a request through the real Fiber app and returns status + body.
+func doReq(t *testing.T, app *fiber.App, method, path string) (int, string) {
+	t.Helper()
+
+	resp, err := app.Test(httptest.NewRequest(method, path, nil))
+	require.NoError(t, err)
+
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	return resp.StatusCode, string(body)
+}
+
+// TestNew_SuppressesAutoMount proves the wrapper registers NO spec/docs routes:
+// /openapi.json and /docs on the group root must 404, even after an operation is
+// registered.
+func TestNew_SuppressesAutoMount(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	api := New(app, app.Group("/"), testConfig())
+	registerEcho(api)
+
+	for _, p := range []string{"/openapi.json", "/openapi.yaml", "/docs", "/openapi"} {
+		status, _ := doReq(t, app, http.MethodGet, p)
+		assert.Equalf(t, http.StatusNotFound, status, "auto-mount must be suppressed for %s", p)
+	}
+}
+
+// TestNew_ServersPopulated proves supplied servers land in the spec.
+func TestNew_ServersPopulated(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	api := New(app, app.Group("/"), testConfig())
+
+	servers := api.OpenAPI().Servers
+	require.Len(t, servers, 2)
+	assert.Equal(t, "https://api.example.com", servers[0].URL)
+	assert.Equal(t, "https://api.staging.example.com", servers[1].URL)
+
+	assert.Equal(t, "Test API", api.OpenAPI().Info.Title)
+	assert.Equal(t, "1.0.0", api.OpenAPI().Info.Version)
+	assert.Equal(t, "test description", api.OpenAPI().Info.Description)
+}
+
+// TestNew_NoServers proves the empty-servers branch leaves Servers unset.
+func TestNew_NoServers(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	cfg := testConfig()
+	cfg.Servers = nil
+	api := New(app, app.Group("/"), cfg)
+
+	assert.Empty(t, api.OpenAPI().Servers)
+}
+
+// TestNew_NoSchemaLeak proves the SchemaLinkTransformer is stripped: response
+// bodies serialize exactly as written, with no injected `$schema` field.
+func TestNew_NoSchemaLeak(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	api := New(app, app.Group("/"), testConfig())
+	registerEcho(api)
+
+	req := httptest.NewRequest(http.MethodPost, "/echo", strings.NewReader(`{"name":"abc"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", body)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(body, &m))
+
+	_, hasSchema := m["$schema"]
+	assert.False(t, hasSchema, "Transformers must be cleared; got $schema leak: %s", body)
+	assert.Equal(t, "abc", m["name"])
+}
+
+// TestDeclareBearerAuth_AddsScheme proves the BearerAuth scheme is registered.
+func TestDeclareBearerAuth_AddsScheme(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	api := New(app, app.Group("/"), testConfig())
+
+	DeclareBearerAuth(api)
+
+	scheme := api.OpenAPI().Components.SecuritySchemes["BearerAuth"]
+	require.NotNil(t, scheme)
+	assert.Equal(t, "http", scheme.Type)
+	assert.Equal(t, "bearer", scheme.Scheme)
+	assert.Equal(t, "JWT", scheme.BearerFormat)
+	assert.NotEmpty(t, scheme.Description)
+}
+
+// TestDeclareBearerAuth_Idempotent proves a second declaration is a no-op
+// overwrite (still exactly one BearerAuth scheme).
+func TestDeclareBearerAuth_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	api := New(app, app.Group("/"), testConfig())
+
+	DeclareBearerAuth(api)
+	DeclareBearerAuth(api)
+
+	assert.Len(t, api.OpenAPI().Components.SecuritySchemes, 1)
+	assert.NotNil(t, api.OpenAPI().Components.SecuritySchemes["BearerAuth"])
+}
+
+// TestDeclareBearerAuth_NilSafe proves nil api does not panic.
+func TestDeclareBearerAuth_NilSafe(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() { DeclareBearerAuth(nil) })
+}
+
+// TestServeSpec_MountsThreeRoutes proves the three spec/docs routes mount under
+// prefix and serve the expected content types.
+func TestServeSpec_MountsThreeRoutes(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	api := New(app, app.Group("/"), testConfig())
+	registerEcho(api)
+
+	ServeSpec(app, api, &libLog.NopLogger{}, "/v1", "Test Docs")
+
+	t.Run("openapi.json", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/v1/openapi.json", nil))
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Contains(t, resp.Header.Get(fiber.HeaderContentType), "application/json")
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var spec map[string]any
+		require.NoError(t, json.Unmarshal(body, &spec))
+		assert.Contains(t, spec, "openapi")
+	})
+
+	t.Run("openapi.yaml", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/v1/openapi.yaml", nil))
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Contains(t, resp.Header.Get(fiber.HeaderContentType), "application/yaml")
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), "openapi:")
+	})
+
+	t.Run("docs with relaxed CSP", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/v1/docs", nil))
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Contains(t, resp.Header.Get(fiber.HeaderContentType), "text/html")
+		assert.Equal(t, scalarCSP, resp.Header.Get("Content-Security-Policy"))
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), "Test Docs")
+		assert.Contains(t, string(body), "/v1/openapi.json")
+		assert.Contains(t, string(body), "@scalar/api-reference")
+	})
+}
+
+// TestServeSpec_NilAPI proves nil api mounts nothing and does not panic.
+func TestServeSpec_NilAPI(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+
+	assert.NotPanics(t, func() {
+		ServeSpec(app, nil, &libLog.NopLogger{}, "/v1", "Test Docs")
+	})
+
+	status, _ := doReq(t, app, http.MethodGet, "/v1/openapi.json")
+	assert.Equal(t, http.StatusNotFound, status, "no routes when api is nil")
+}
+
+// recordingLogger captures the last Log call so the skip-on-failure path can be
+// asserted.
+type recordingLogger struct {
+	libLog.NopLogger
+	called bool
+	msg    string
+}
+
+func (l *recordingLogger) Log(_ context.Context, _ libLog.Level, msg string, _ ...libLog.Field) {
+	l.called = true
+	l.msg = msg
+}
+
+// TestServeSpec_RenderFailure_LogsAndSkips proves that when the spec cannot be
+// rendered, ServeSpec logs and registers no routes (no panic, no partial mount).
+//
+// Note on coverage: huma's OpenAPI().YAML() internally calls json.Marshal(o)
+// first, so any value that breaks JSON marshaling breaks YAML() first and we
+// return on the YAML branch. The standalone specJSON-error branch in ServeSpec
+// is therefore structurally unreachable defensive code (a verbatim port); it is
+// retained as cheap safety, not exercised here.
+func TestServeSpec_RenderFailure_LogsAndSkips(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	api := New(app, app.Group("/"), testConfig())
+
+	// Inject an un-serializable extension into the spec so YAML() fails
+	// deterministically (its internal json.Marshal chokes on the channel).
+	api.OpenAPI().Extensions = map[string]any{"x-bad": make(chan int)}
+
+	logger := &recordingLogger{}
+	assert.NotPanics(t, func() {
+		ServeSpec(app, api, logger, "/v1", "Test Docs")
+	})
+
+	assert.True(t, logger.called, "render failure must be logged")
+	assert.Contains(t, logger.msg, "yaml", "the YAML render branch is the one hit")
+
+	status, _ := doReq(t, app, http.MethodGet, "/v1/openapi.json")
+	assert.Equal(t, http.StatusNotFound, status, "no routes registered on render failure")
+}
+
+// TestSchemaParity_ErrorSchemaCarriesCode is the org-wide shape lock: after
+// problem.Install(), the generated OpenAPI error component schema must expose the
+// optional `code` property (alongside the RFC 9457 status/title/detail). The
+// test fails if Detail ever loses the field. It restores the global override so
+// it does not leak into sibling tests.
+func TestSchemaParity_ErrorSchemaCarriesCode(t *testing.T) {
+	// NOT parallel: mutates the process-global huma.NewError.
+	original := huma.NewError
+	t.Cleanup(func() { huma.NewError = original })
+
+	problem.Install()
+
+	app := fiber.New()
+	api := New(app, app.Group("/"), testConfig())
+
+	// Register an operation that can produce a validation error so Huma wires the
+	// error schema into the components.
+	registerEcho(api)
+
+	// Force the error schema into the registry via the override return type.
+	errSchema := findErrorSchema(t, api)
+	require.NotNil(t, errSchema, "an error component schema must be generated")
+
+	_, hasCode := errSchema.Properties["code"]
+	assert.True(t, hasCode, "error schema must carry the optional `code` property")
+
+	// The RFC 9457 quartet must remain.
+	for _, p := range []string{"status", "title", "detail"} {
+		_, ok := errSchema.Properties[p]
+		assert.Truef(t, ok, "error schema must carry %q", p)
+	}
+
+	// Belt-and-suspenders: the marshaled spec contains the example domain code.
+	raw, err := json.Marshal(api.OpenAPI())
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "SPB-3002", "code property example should be present in the spec")
+}
+
+// findErrorSchema locates the registered component schema that carries the
+// promoted `code` property (the *Detail shape). It is resilient to the schema's
+// component name.
+func findErrorSchema(t *testing.T, api huma.API) *huma.Schema {
+	t.Helper()
+
+	for name, s := range api.OpenAPI().Components.Schemas.Map() {
+		if s == nil || s.Properties == nil {
+			continue
+		}
+
+		if _, ok := s.Properties["code"]; !ok {
+			continue
+		}
+
+		_, hasStatus := s.Properties["status"]
+		_, hasDetail := s.Properties["detail"]
+		if hasStatus && hasDetail {
+			t.Logf("error schema component: %s", name)
+			return s
+		}
+	}
+
+	return nil
+}

--- a/commons/net/http/openapi/openapi_test.go
+++ b/commons/net/http/openapi/openapi_test.go
@@ -366,3 +366,49 @@ func findErrorSchema(t *testing.T, api huma.API) *huma.Schema {
 
 	return nil
 }
+
+// TestDocsHTML_EscapesInterpolatedValues proves the docs page HTML-escapes the
+// title and spec URL, so a value carrying HTML/attribute-breaking characters
+// cannot inject markup or script into /docs.
+func TestDocsHTML_EscapesInterpolatedValues(t *testing.T) {
+	t.Parallel()
+
+	out := string(docsHTML(`</title><script>alert(1)</script>`, `x"><img src=y onerror=alert(1)>`))
+
+	assert.NotContains(t, out, "<script>alert(1)</script>", "raw script must not survive into the docs HTML")
+	assert.NotContains(t, out, `x"><img`, "attribute-breaking spec URL must be escaped")
+	assert.Contains(t, out, "&lt;script&gt;", "title must be HTML-escaped")
+	assert.Contains(t, out, "&#34;&gt;&lt;img", "spec URL must be HTML-escaped")
+}
+
+// TestServeSpec_NilApp proves a nil app is a no-op and does not panic, even with
+// a valid api.
+func TestServeSpec_NilApp(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	api := New(app, app.Group("/"), testConfig())
+	registerEcho(api)
+
+	assert.NotPanics(t, func() {
+		ServeSpec(nil, api, &libLog.NopLogger{}, "/v1", "Test Docs")
+	})
+}
+
+// TestServeSpec_NilLogger_RenderFailure_NoPanic proves a nil logger falls back to
+// a no-op logger: even on a render failure (which logs), ServeSpec must not panic
+// and registers no routes.
+func TestServeSpec_NilLogger_RenderFailure_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	api := New(app, app.Group("/"), testConfig())
+	api.OpenAPI().Extensions = map[string]any{"x-bad": make(chan int)}
+
+	assert.NotPanics(t, func() {
+		ServeSpec(app, api, nil, "/v1", "Test Docs")
+	})
+
+	status, _ := doReq(t, app, http.MethodGet, "/v1/openapi.json")
+	assert.Equal(t, http.StatusNotFound, status, "no routes registered on render failure")
+}

--- a/commons/net/http/problem/install.go
+++ b/commons/net/http/problem/install.go
@@ -1,0 +1,100 @@
+package problem
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// genericServerErrorDetail is the static, leak-free public detail served for
+// every status>=500 error built through the installed override. It carries no
+// operation name and no underlying cause, so a careless call site (including a
+// direct huma.Error500(rawErr.Error())) cannot interpolate an internal error
+// into a client-visible 5xx body.
+const genericServerErrorDetail = "internal error"
+
+// installOnce serializes the override of the process-global huma.NewError. The
+// override is deterministic, so installing exactly once per process is correct;
+// the Once also makes concurrent installs (e.g. several API constructions in
+// parallel tests) race-free, delivering on the idempotency this function's doc
+// contract promises.
+var installOnce sync.Once
+
+// Install overrides the process-global huma.NewError so every error Huma
+// constructs — domain errors routed through MapError as well as the framework's
+// own validation/404/etc. errors — is a *Detail. This is what makes Huma's
+// generated OpenAPI error schema carry the shared shape (including the optional
+// `code` property) with zero per-operation registration.
+//
+// It is idempotent: each service's runtime bootstrap and spec-gen entrypoint may
+// call it once, and a double call is safe because the override is itself
+// deterministic.
+//
+// huma.NewError is a package var, so this MUST run before any operation is
+// registered on the runtime API or the spec-gen API, or the generated schema and
+// the runtime bodies will diverge.
+//
+// MERGE SEMANTICS (this is the crux of the promotion):
+//   - status >= 500: the body is scrubbed to the static genericServerErrorDetail
+//     and NO errs are folded. This is underwriter's central safety — it closes
+//     the direct-huma.Error5xx(rawErr) info-leak that br-sfn's old override left
+//     open by passing the raw msg/errs straight through.
+//   - status  < 500: msg is passed through and errs are folded into Errors[] in
+//     order (skip nil, honor huma.ErrorDetailer) — exactly like the stock
+//     huma.NewError, so native 422 validation errors keep their per-field
+//     errors[] list.
+//
+// For framework errors Code stays empty (dropped by omitempty) and Type stays at
+// the RFC default about:blank.
+func Install() {
+	installOnce.Do(func() {
+		huma.NewError = newError
+	})
+}
+
+// newError is the override body installed over huma.NewError: it builds a
+// *Detail for every error Huma constructs, scrubbing >=500 centrally. It is a
+// named function (not an inline closure) so it can be exercised directly in
+// tests without mutating the process-global, and so installOnce.Do assigns a
+// stable reference.
+func newError(status int, msg string, errs ...error) huma.StatusError {
+	if status >= http.StatusInternalServerError {
+		return &Detail{
+			ErrorModel: huma.ErrorModel{
+				Status: status,
+				Title:  http.StatusText(status),
+				Detail: genericServerErrorDetail,
+			},
+		}
+	}
+
+	details := make([]*huma.ErrorDetail, 0, len(errs))
+
+	for _, e := range errs {
+		if e == nil {
+			continue
+		}
+
+		if converted, ok := e.(huma.ErrorDetailer); ok {
+			details = append(details, converted.ErrorDetail())
+			continue
+		}
+
+		details = append(details, &huma.ErrorDetail{Message: e.Error()})
+	}
+
+	var folded []*huma.ErrorDetail
+	if len(details) > 0 {
+		folded = details
+	}
+
+	return &Detail{
+		ErrorModel: huma.ErrorModel{
+			Status: status,
+			Title:  http.StatusText(status),
+			Detail: msg,
+			Errors: folded,
+		},
+	}
+}

--- a/commons/net/http/problem/install_test.go
+++ b/commons/net/http/problem/install_test.go
@@ -1,0 +1,135 @@
+//go:build unit
+
+package problem
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// detailErr is a test error implementing huma.ErrorDetailer to prove newError
+// honors the interface (folding the carried *huma.ErrorDetail rather than the
+// Error() string) on the <500 path.
+type detailErr struct {
+	d *huma.ErrorDetail
+}
+
+func (e *detailErr) Error() string                  { return e.d.Message }
+func (e *detailErr) ErrorDetail() *huma.ErrorDetail { return e.d }
+
+// asDetail asserts the StatusError is a *Detail and returns it.
+func asDetail(t *testing.T, se huma.StatusError) *Detail {
+	t.Helper()
+
+	d, ok := se.(*Detail)
+	require.True(t, ok, "expected *Detail, got %T", se)
+
+	return d
+}
+
+// TestNewError_ServerError_Scrubbed is the central safety assertion: every
+// status>=500 is scrubbed to the static detail and folds NO errs, even when a
+// raw cause is passed (the leak underwriter's scrubber closes).
+func TestNewError_ServerError_Scrubbed(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+	} {
+		d := asDetail(t, newError(status, "db password = hunter2", errors.New("leaky raw cause")))
+
+		assert.Equal(t, status, d.Status)
+		assert.Equal(t, http.StatusText(status), d.Title)
+		assert.Equal(t, genericServerErrorDetail, d.Detail, "5xx detail must be scrubbed")
+		assert.Nil(t, d.Errors, "5xx must fold NO errs")
+		assert.Empty(t, d.Code)
+		assert.Empty(t, d.Type, "Type stays RFC default about:blank (empty)")
+	}
+}
+
+// TestNewError_ClientError_PassthroughAndFold proves the <500 path: msg passes
+// through and errs fold into Errors[] in order — preserving Huma's native 422
+// field-error behavior.
+func TestNewError_ClientError_PassthroughAndFold(t *testing.T) {
+	t.Parallel()
+
+	d := asDetail(t, newError(
+		http.StatusUnprocessableEntity,
+		"validation failed",
+		errors.New("field a invalid"),
+		errors.New("field b invalid"),
+	))
+
+	assert.Equal(t, http.StatusUnprocessableEntity, d.Status)
+	assert.Equal(t, "validation failed", d.Detail)
+	require.Len(t, d.Errors, 2)
+	assert.Equal(t, "field a invalid", d.Errors[0].Message)
+	assert.Equal(t, "field b invalid", d.Errors[1].Message, "order preserved")
+}
+
+// TestNewError_ClientError_SkipsNilErrs proves nil entries are skipped and an
+// all-nil / empty slice yields a nil Errors (not an empty []).
+func TestNewError_ClientError_SkipsNilErrs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil interspersed", func(t *testing.T) {
+		t.Parallel()
+
+		d := asDetail(t, newError(http.StatusBadRequest, "msg", nil, errors.New("real"), nil))
+
+		require.Len(t, d.Errors, 1)
+		assert.Equal(t, "real", d.Errors[0].Message)
+	})
+
+	t.Run("no errs at all", func(t *testing.T) {
+		t.Parallel()
+
+		d := asDetail(t, newError(http.StatusBadRequest, "msg"))
+		assert.Nil(t, d.Errors, "empty slice must become nil, not []")
+	})
+
+	t.Run("all nil", func(t *testing.T) {
+		t.Parallel()
+
+		d := asDetail(t, newError(http.StatusNotFound, "missing", nil, nil))
+		assert.Nil(t, d.Errors)
+	})
+}
+
+// TestNewError_HonorsErrorDetailer proves a huma.ErrorDetailer's carried detail
+// is folded (not its Error() string) on the <500 path.
+func TestNewError_HonorsErrorDetailer(t *testing.T) {
+	t.Parallel()
+
+	carried := &huma.ErrorDetail{Message: "carried", Location: "body.name", Value: "x"}
+	d := asDetail(t, newError(http.StatusBadRequest, "msg", &detailErr{d: carried}))
+
+	require.Len(t, d.Errors, 1)
+	assert.Same(t, carried, d.Errors[0], "ErrorDetailer's *ErrorDetail folded verbatim")
+	assert.Equal(t, "body.name", d.Errors[0].Location)
+}
+
+// TestInstall_OverridesGlobal_Idempotent proves Install swaps the process-global
+// huma.NewError to our *Detail-producing override and that a second call is a
+// safe no-op. It restores the global afterward to avoid leaking across packages.
+func TestInstall_OverridesGlobal_Idempotent(t *testing.T) {
+	// NOT parallel: mutates the process-global huma.NewError.
+	original := huma.NewError
+	t.Cleanup(func() { huma.NewError = original })
+
+	Install()
+	first := asDetail(t, huma.NewError(http.StatusBadRequest, "after install"))
+	assert.Equal(t, "after install", first.Detail)
+
+	// A second Install must not re-wrap or otherwise change behavior.
+	Install()
+	scrubbed := asDetail(t, huma.NewError(http.StatusInternalServerError, "raw cause"))
+	assert.Equal(t, genericServerErrorDetail, scrubbed.Detail)
+}

--- a/commons/net/http/problem/maperror.go
+++ b/commons/net/http/problem/maperror.go
@@ -1,0 +1,75 @@
+package problem
+
+import (
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// MapError translates err into the shared RFC 9457 Detail. It applies the
+// generic policy; each service supplies its own code extraction (codeOf) and
+// code->status table (statusOf):
+//
+//   - nil error, or codeOf reporting !ok -> 500 "internal error" carrying the
+//     fallbackCode (when non-empty) in the machine-readable Code + Type fields.
+//     A nil error at an error mapper is a handler bug, not success; returning a
+//     nil here would render a 200 and hide the bug, so the safe default is the
+//     canonical sanitized 500.
+//   - codeOf -> (code, msg, true) -> a *Detail with Status=statusOf(code). When
+//     code is non-empty, Code holds the bare domain code and Type is the flat
+//     URI (BaseURI + "/" + code); the code is NOT appended to detail. 5xx details
+//     are sanitized to "internal error" so a raw cause never leaks, while
+//     Code/Type still let clients branch on a sanitized 500. An empty code yields
+//     a bare body (no Code, default Type) for rails without a code taxonomy.
+//
+// codeOf extracts a (code, msg, ok) triple from err: ok=false signals the error
+// is not a recognized domain error (fall back to the canonical 500). statusOf
+// maps a code to its HTTP status. fallbackCode is the code carried in the body
+// when the error is nil or unrecognized.
+//
+// It returns a concrete *Detail directly rather than round-tripping through
+// huma.NewError, so the result is independent of whether Install ran.
+func MapError(
+	err error,
+	codeOf func(error) (code, msg string, ok bool),
+	statusOf func(code string) int,
+	fallbackCode string,
+) error {
+	if err == nil {
+		return newProblem(http.StatusInternalServerError, genericServerErrorDetail, fallbackCode)
+	}
+
+	code, msg, ok := codeOf(err)
+	if !ok {
+		return newProblem(http.StatusInternalServerError, genericServerErrorDetail, fallbackCode)
+	}
+
+	status := statusOf(code)
+
+	detail := msg
+	if status >= http.StatusInternalServerError {
+		detail = genericServerErrorDetail
+	}
+
+	return newProblem(status, detail, code)
+}
+
+// newProblem assembles a *Detail with the title defaulted from the status text
+// and the type/code wiring: when code is non-empty, Code is set and Type is
+// BaseURI + "/" + code; otherwise the body stays bare (no Code, default Type).
+func newProblem(status int, detail, code string) *Detail {
+	pd := &Detail{
+		ErrorModel: huma.ErrorModel{
+			Status: status,
+			Title:  http.StatusText(status),
+			Detail: detail,
+		},
+	}
+
+	if code != "" {
+		pd.Code = code
+		pd.Type = BaseURI + "/" + code
+	}
+
+	return pd
+}

--- a/commons/net/http/problem/maperror.go
+++ b/commons/net/http/problem/maperror.go
@@ -10,11 +10,13 @@ import (
 // generic policy; each service supplies its own code extraction (codeOf) and
 // code->status table (statusOf):
 //
-//   - nil error, or codeOf reporting !ok -> 500 "internal error" carrying the
-//     fallbackCode (when non-empty) in the machine-readable Code + Type fields.
-//     A nil error at an error mapper is a handler bug, not success; returning a
-//     nil here would render a 200 and hide the bug, so the safe default is the
-//     canonical sanitized 500.
+//   - nil error, a nil codeOf/statusOf callback, or codeOf reporting !ok -> 500
+//     "internal error" carrying the fallbackCode (when non-empty) in the
+//     machine-readable Code + Type fields. A nil error at an error mapper is a
+//     handler bug, not success; returning a nil here would render a 200 and hide
+//     the bug, so the safe default is the canonical sanitized 500. A miswired
+//     caller passing a nil callback gets the same sanitized 500 instead of a
+//     panic.
 //   - codeOf -> (code, msg, true) -> a *Detail with Status=statusOf(code). When
 //     code is non-empty, Code holds the bare domain code and Type is the flat
 //     URI (BaseURI + "/" + code); the code is NOT appended to detail. 5xx details
@@ -35,7 +37,7 @@ func MapError(
 	statusOf func(code string) int,
 	fallbackCode string,
 ) error {
-	if err == nil {
+	if err == nil || codeOf == nil || statusOf == nil {
 		return newProblem(http.StatusInternalServerError, genericServerErrorDetail, fallbackCode)
 	}
 

--- a/commons/net/http/problem/maperror_test.go
+++ b/commons/net/http/problem/maperror_test.go
@@ -109,3 +109,41 @@ func TestMapError_Coded_EmptyCode_BareBody(t *testing.T) {
 	assert.Empty(t, d.Code)
 	assert.Empty(t, d.Type)
 }
+
+// TestMapError_NilCallbacks_SanitizedFallback500 proves a miswired caller passing
+// a nil codeOf or statusOf gets the canonical sanitized 500 (carrying the
+// fallbackCode) instead of a panic.
+func TestMapError_NilCallbacks_SanitizedFallback500(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil codeOf", func(t *testing.T) {
+		t.Parallel()
+
+		d := mapErrDetail(t, MapError(errors.New("x"), nil, staticStatusOf, "SPB-0000"))
+
+		assert.Equal(t, http.StatusInternalServerError, d.Status)
+		assert.Equal(t, genericServerErrorDetail, d.Detail)
+		assert.Equal(t, "SPB-0000", d.Code)
+		assert.Equal(t, BaseURI+"/SPB-0000", d.Type)
+	})
+
+	t.Run("nil statusOf", func(t *testing.T) {
+		t.Parallel()
+
+		d := mapErrDetail(t, MapError(errors.New("x"), neverCodeOf, nil, "SPB-0000"))
+
+		assert.Equal(t, http.StatusInternalServerError, d.Status)
+		assert.Equal(t, genericServerErrorDetail, d.Detail)
+		assert.Equal(t, "SPB-0000", d.Code)
+	})
+
+	t.Run("both nil with empty fallback yields a bare body", func(t *testing.T) {
+		t.Parallel()
+
+		d := mapErrDetail(t, MapError(errors.New("x"), nil, nil, ""))
+
+		assert.Equal(t, http.StatusInternalServerError, d.Status)
+		assert.Empty(t, d.Code)
+		assert.Empty(t, d.Type)
+	})
+}

--- a/commons/net/http/problem/maperror_test.go
+++ b/commons/net/http/problem/maperror_test.go
@@ -1,0 +1,111 @@
+//go:build unit
+
+package problem
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mapErrDetail unwraps the error returned by MapError into a *Detail.
+func mapErrDetail(t *testing.T, err error) *Detail {
+	t.Helper()
+
+	require.Error(t, err)
+
+	d, ok := err.(*Detail)
+	require.True(t, ok, "expected *Detail, got %T", err)
+
+	return d
+}
+
+// neverCodeOf is a codeOf that always reports !ok.
+func neverCodeOf(error) (string, string, bool) { return "", "", false }
+
+// staticStatusOf maps any code to 422 (a <500 status) for the happy paths.
+func staticStatusOf(string) int { return http.StatusUnprocessableEntity }
+
+func TestMapError_NilError_SanitizedFallback500(t *testing.T) {
+	t.Parallel()
+
+	d := mapErrDetail(t, MapError(nil, neverCodeOf, staticStatusOf, "SPB-0000"))
+
+	assert.Equal(t, http.StatusInternalServerError, d.Status)
+	assert.Equal(t, genericServerErrorDetail, d.Detail)
+	assert.Equal(t, "SPB-0000", d.Code)
+	assert.Equal(t, BaseURI+"/SPB-0000", d.Type)
+}
+
+func TestMapError_Unrecognized_SanitizedFallback500(t *testing.T) {
+	t.Parallel()
+
+	d := mapErrDetail(t, MapError(errors.New("some infra error"), neverCodeOf, staticStatusOf, "SPB-0000"))
+
+	assert.Equal(t, http.StatusInternalServerError, d.Status)
+	assert.Equal(t, genericServerErrorDetail, d.Detail)
+	assert.Equal(t, "SPB-0000", d.Code)
+	assert.Equal(t, BaseURI+"/SPB-0000", d.Type)
+}
+
+// TestMapError_Unrecognized_EmptyFallback proves the SPI path: empty fallbackCode
+// yields a bare sanitized 500 with no Code/Type.
+func TestMapError_Unrecognized_EmptyFallback(t *testing.T) {
+	t.Parallel()
+
+	d := mapErrDetail(t, MapError(errors.New("infra"), neverCodeOf, staticStatusOf, ""))
+
+	assert.Equal(t, http.StatusInternalServerError, d.Status)
+	assert.Equal(t, genericServerErrorDetail, d.Detail)
+	assert.Empty(t, d.Code)
+	assert.Empty(t, d.Type)
+}
+
+// TestMapError_Coded_SetsCodeAndType proves the coded <500 path: status from
+// statusOf, msg passes through, Code set, Type = BaseURI + "/" + code.
+func TestMapError_Coded_SetsCodeAndType(t *testing.T) {
+	t.Parallel()
+
+	codeOf := func(error) (string, string, bool) { return "SPB-3002", "amount exceeds limit", true }
+
+	d := mapErrDetail(t, MapError(errors.New("domain"), codeOf, staticStatusOf, "SPB-0000"))
+
+	assert.Equal(t, http.StatusUnprocessableEntity, d.Status)
+	assert.Equal(t, "amount exceeds limit", d.Detail, "<500 msg passes through")
+	assert.Equal(t, "SPB-3002", d.Code)
+	assert.Equal(t, BaseURI+"/SPB-3002", d.Type)
+}
+
+// TestMapError_Coded_5xxScrubbedKeepsCode proves a coded 5xx scrubs the detail to
+// "internal error" while still carrying Code/Type so clients can branch.
+func TestMapError_Coded_5xxScrubbedKeepsCode(t *testing.T) {
+	t.Parallel()
+
+	codeOf := func(error) (string, string, bool) { return "SPB-9001", "raw db cause", true }
+	statusOf := func(string) int { return http.StatusServiceUnavailable }
+
+	d := mapErrDetail(t, MapError(errors.New("domain"), codeOf, statusOf, "SPB-0000"))
+
+	assert.Equal(t, http.StatusServiceUnavailable, d.Status)
+	assert.Equal(t, genericServerErrorDetail, d.Detail, "5xx detail sanitized")
+	assert.Equal(t, "SPB-9001", d.Code, "Code still carried on sanitized 5xx")
+	assert.Equal(t, BaseURI+"/SPB-9001", d.Type)
+}
+
+// TestMapError_Coded_EmptyCode_BareBody proves the SPI taxonomy-less path: a
+// recognized error reporting an empty code yields a bare body (no Code/Type).
+func TestMapError_Coded_EmptyCode_BareBody(t *testing.T) {
+	t.Parallel()
+
+	codeOf := func(error) (string, string, bool) { return "", "bad request", true }
+
+	d := mapErrDetail(t, MapError(errors.New("domain"), codeOf, staticStatusOf, ""))
+
+	assert.Equal(t, http.StatusUnprocessableEntity, d.Status)
+	assert.Equal(t, "bad request", d.Detail)
+	assert.Empty(t, d.Code)
+	assert.Empty(t, d.Type)
+}

--- a/commons/net/http/problem/problem.go
+++ b/commons/net/http/problem/problem.go
@@ -1,0 +1,40 @@
+// Package problem is the rail-agnostic, org-wide RFC 9457 error model for
+// Huma-served APIs. It exposes the shared Detail body (huma.ErrorModel plus a
+// flat, machine-readable Code), an Install() override of the process-global
+// huma.NewError that makes EVERY Huma-constructed error a *Detail while
+// centrally scrubbing every >=500 body, and a generic MapError mapper that
+// translates a domain-layer error into the shared Detail.
+//
+// The package imports github.com/danielgtaylor/huma/v2 only — no Fiber, no
+// transport adapter — so it is the light, transport-free half of the wrapper.
+// The heavier Fiber binding lives in commons/net/http/openapi and deliberately
+// does NOT import this package: error policy is the consumer bootstrap's
+// concern (it calls Install), the binding's is metadata + mounting.
+//
+// This package is platform glue shared by every Lerian service; it must not
+// import any bounded-context package.
+package problem
+
+import "github.com/danielgtaylor/huma/v2"
+
+// BaseURI is the single source of truth for the RFC 9457 `type` URI shape. The
+// full `type` for a coded error is BaseURI + "/" + code (flat + versioned),
+// e.g. https://errors.lerian.studio/v1/SPB-3002. The /v1 segment versions the
+// published error catalog so a `type` URI stays a stable, dereferenceable
+// identifier even if the catalog's meaning model later evolves. Never hardcode
+// the literal a second time; reference this constant.
+const BaseURI = "https://errors.lerian.studio/v1"
+
+// Detail is the single RFC 9457 error body for every Lerian rail. It embeds
+// Huma's ErrorModel (type/title/status/detail/instance/errors) and adds the
+// flat machine-readable domain code.
+//
+// *Detail satisfies huma.StatusError via method promotion from the embedded
+// ErrorModel (Error/GetStatus/ContentType/Add). Installing it as the
+// huma.NewError override (see Install) makes Huma's generated OpenAPI error
+// schema reflect this type, including the optional `code` property; the field
+// is dropped by omitempty for code-less rails.
+type Detail struct {
+	huma.ErrorModel
+	Code string `json:"code,omitempty" doc:"Stable domain error code, e.g. SPB-3002" example:"SPB-3002"`
+}

--- a/commons/net/http/problem/problem_test.go
+++ b/commons/net/http/problem/problem_test.go
@@ -1,0 +1,87 @@
+//go:build unit
+
+package problem
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBaseURI(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "https://errors.lerian.studio/v1", BaseURI)
+}
+
+// TestDetail_SatisfiesStatusError proves *Detail implements huma.StatusError via
+// method promotion from the embedded ErrorModel — the property that lets the
+// override and MapError return a *Detail wherever Huma expects a StatusError.
+func TestDetail_SatisfiesStatusError(t *testing.T) {
+	t.Parallel()
+
+	var _ huma.StatusError = (*Detail)(nil)
+
+	d := &Detail{
+		ErrorModel: huma.ErrorModel{Status: http.StatusTeapot, Title: "I'm a teapot", Detail: "nope"},
+	}
+
+	var se huma.StatusError = d
+	assert.Equal(t, http.StatusTeapot, se.GetStatus())
+	assert.NotEmpty(t, se.Error())
+}
+
+// TestDetail_JSON_OmitsEmptyCode asserts the omitempty contract: a code-less
+// Detail must not emit a `code` key on the wire, so code-less rails keep a bare
+// RFC 9457 body.
+func TestDetail_JSON_OmitsEmptyCode(t *testing.T) {
+	t.Parallel()
+
+	d := &Detail{
+		ErrorModel: huma.ErrorModel{
+			Status: http.StatusBadRequest,
+			Title:  http.StatusText(http.StatusBadRequest),
+			Detail: "bad input",
+		},
+	}
+
+	raw, err := json.Marshal(d)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+
+	_, hasCode := m["code"]
+	assert.False(t, hasCode, "empty Code must be dropped by omitempty, got %s", raw)
+	assert.Equal(t, "bad input", m["detail"])
+	assert.EqualValues(t, http.StatusBadRequest, m["status"])
+}
+
+// TestDetail_JSON_IncludesCode asserts that once Code is set it serializes under
+// the `code` key.
+func TestDetail_JSON_IncludesCode(t *testing.T) {
+	t.Parallel()
+
+	d := &Detail{
+		ErrorModel: huma.ErrorModel{
+			Status: http.StatusUnprocessableEntity,
+			Title:  http.StatusText(http.StatusUnprocessableEntity),
+			Detail: "boom",
+			Type:   BaseURI + "/SPB-3002",
+		},
+		Code: "SPB-3002",
+	}
+
+	raw, err := json.Marshal(d)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+
+	assert.Equal(t, "SPB-3002", m["code"])
+	assert.Equal(t, BaseURI+"/SPB-3002", m["type"])
+}

--- a/docs/plans/2026-06-13-huma-openapi-wrapper-promotion.md
+++ b/docs/plans/2026-06-13-huma-openapi-wrapper-promotion.md
@@ -1,0 +1,269 @@
+# Huma OpenAPI Wrapper Promotion to lib-commons — Implementation Plan
+
+> **For implementers:** Use ring:executing-plans (rolling wave: implement the
+> detailed phase → user checkpoint → detail the next phase → implement → repeat).
+> This document is the living source of truth — task elaboration for later
+> phases is written back into it during execution.
+
+**Goal:** Promote the Huma v2 + OpenAPI 3.1 Fiber-binding wrapper and the RFC 9457
+`ProblemDetail` error model into `lib-commons/v5` as the single org-wide HTTP/OpenAPI
+layer, then migrate `underwriter` and `br-sfn` off their per-repo copies onto it.
+
+**Architecture:** Two new packages under `commons/net/http/`. A heavy
+`openapi` package (Fiber v2 binding via `humafiber`, metadata, auto-mount
+suppression, Bearer scheme, Scalar spec serving) and a light huma-only `problem`
+package (RFC 9457 `Detail` type, `huma.NewError` override with central ≥500
+scrub, generic domain-error mapper). The merged wrapper is the SUPERSET of the
+two existing copies: br-sfn's richer feature surface + underwriter's safer
+central 5xx-scrub. Topology decision (Fred, 2026-06-13): **root module**, not a
+submodule — every Lerian service (midaz, reporter, matcher, …) will adopt the
+wrapper, so isolating fiber/v3 from non-consumers protects an empty set. The
+fiber/v3 module-graph drag is accepted and inherent to `humafiber`'s dual-major
+import; Trivy-class scanners will flag future fiber/v3 CVEs on the unused v3 path
+(waivable false positive), `govulncheck` stays quiet (v3 unreachable).
+
+**Tech Stack:** Go 1.26.x, Huma v2 (`github.com/danielgtaylor/huma/v2 v2.38.0`),
+`humafiber` adapter (Fiber v2 path, `NewV2WithGroup`), `gofiber/fiber/v2
+v2.52.13`, `lib-observability/log`, testify, build-tag unit tests.
+
+## Phase Overview
+
+| Phase | Milestone | Epics | Status |
+|-------|-----------|-------|--------|
+| 1 | lib-commons exposes `openapi` + `problem`; unit-green ≥80%; beta released | 1.1, 1.2, 1.3 | Detailed |
+| 2 | underwriter consumes lib-commons wrapper; local copy deleted; CI green | 2.1, 2.2 | Epic-level |
+| 3 | br-sfn (SPB + SPI×4 binaries) consumes lib-commons wrapper; copies deleted; CI green | 3.1, 3.2, 3.3 | Epic-level |
+| 4 | lib-commons stable `v5.6.0`; both consumers pinned to stable; replaces dropped | 4.1 | Epic-level |
+
+---
+
+## Design Reference (the contract every phase binds to)
+
+### Package `commons/net/http/openapi` (imports fiber/v2, humafiber, huma, lib-observability/log)
+
+```go
+type Config struct {
+    Title       string
+    Version     string
+    Description string
+    Servers     []string
+}
+
+// Metadata + bind. Strips SchemaLinkTransformer (no $schema leak), clears
+// OnAddOperation/CreateHooks/SchemasPath, suppresses auto-mount
+// (OpenAPIPath="" DocsPath=""), binds via humafiber.NewV2WithGroup. No error
+// policy here. Operations registered by callers.
+func New(app *fiber.App, group fiber.Router, cfg Config) huma.API
+
+// Registers the BearerAuth (http/bearer/JWT) security scheme. Nil-safe, idempotent.
+func DeclareBearerAuth(api huma.API)
+
+// Mounts {prefix}/openapi.json, {prefix}/openapi.yaml, {prefix}/docs (Scalar via
+// CDN, per-route relaxed CSP). Snapshots spec once. Caller MUST gate on its
+// Swagger.Enabled flag. Nil-safe on api; logs + skips on render failure.
+func ServeSpec(app *fiber.App, api huma.API, logger libLog.Logger, prefix, title string)
+```
+
+### Package `commons/net/http/problem` (imports huma ONLY — no fiber)
+
+```go
+const BaseURI = "https://errors.lerian.studio/v1" // RFC 9457 type URI base, /v1-versioned catalog
+
+// Uniform org-wide RFC 9457 body. Embeds huma.ErrorModel; adds omitempty Code.
+// Satisfies huma.StatusError by promotion. Code stays absent for code-less rails.
+type Detail struct {
+    huma.ErrorModel
+    Code string `json:"code,omitempty" doc:"Stable domain error code, e.g. SPB-3002" example:"SPB-3002"`
+}
+
+// Install overrides process-global huma.NewError so EVERY huma-constructed error
+// is a *Detail. MERGE SEMANTICS (this is the crux):
+//   - status >= 500: Detail scrubbed to a static "internal error", NO errs folded
+//     (underwriter's central safety — closes the direct-Error5xx-raw-cause leak
+//     br-sfn's old override left open).
+//   - status  < 500: msg passed through, errs folded into Errors[] in order
+//     (preserves Huma's native 422 field errors).
+//   - Code/Type stay empty here (framework errors); omitempty drops Code, Type
+//     stays at RFC default about:blank.
+// sync.Once; deterministic; MUST run before any operation is registered on the
+// runtime API or the spec-gen API or schema/runtime bodies diverge.
+func Install()
+
+// Generic domain mapper (br-sfn's, verbatim semantics). codeOf extracts
+// (code,msg,ok); ok=false or nil err -> canonical sanitized 500 carrying
+// fallbackCode. statusOf maps code->status. When code != "", sets Code and
+// Type = BaseURI+"/"+code; 5xx detail sanitized to "internal error". Returns a
+// concrete *Detail (independent of whether Install ran).
+func MapError(err error, codeOf func(error) (code, msg string, ok bool), statusOf func(code string) int, fallbackCode string) error
+```
+
+**Convergence consequences (declared, greenfield — no external consumers):**
+- underwriter's error SCHEMA gains an optional `code` property (never populated → omitted on the wire). Uniform org-wide shape is the goal, costs underwriter nothing.
+- br-sfn's framework-error 5xx path now scrubs centrally (strictly safer; was a latent leak).
+- Both repos delete their local copies entirely (underwriter `internal/shared/adapters/openapi`; br-sfn `shared/openapi` + `shared/humaerr`).
+
+**Local dev workflow (de-risks the release gate):** Phases 2 & 3 develop against
+the unreleased wrapper via `replace github.com/LerianStudio/lib-commons/v5 =>
+../lib-commons` in each consumer's go.mod. The replace is DROPPED and the real
+version pinned before each consumer PR merges (Phase 4 pins stable).
+
+---
+
+## Phase 1 — lib-commons wrapper (foundation)
+
+**Milestone:** `go test -tags=unit ./commons/net/http/openapi/... ./commons/net/http/problem/...`
+green at ≥80% coverage; `make lint sec vulncheck` green; merged to `develop`;
+beta `v5.6.0-beta.N` released.
+
+### Epic 1.1: `problem` package — RFC 9457 error model
+
+**Goal:** `commons/net/http/problem` exposes `Detail`, `BaseURI`, `Install`, `MapError` with the merged 5xx-scrub semantics, huma-only deps.
+**Scope:** `commons/net/http/problem/` (new dir).
+**Dependencies:** none (huma is added to go.mod in Epic 1.3, but problem is huma-only so go.mod edit can lead here).
+**Done when:** unit tests prove (a) ≥500 scrubbed + no errs folded; (b) <500 msg passthrough + errs folded preserving order; (c) `Detail` JSON omits empty Code, includes it when set; (d) `MapError` nil/unrecognized → sanitized 500 w/ fallbackCode; (e) coded path sets Code+Type, 5xx detail sanitized; (f) `*Detail` satisfies `huma.StatusError`.
+**Status:** Pending
+
+#### Task 1.1.1: Author the `problem` package
+
+- [ ] Done
+
+**Context:** Port and MERGE two existing sources. br-sfn `shared/humaerr/{problemdetail,install,humaerr}.go` supplies `ProblemDetail`+`Code`, `InstallProblemDetail`/`newProblemError`, `MapDomainError`, `ProblemBaseURI`. underwriter `internal/shared/adapters/openapi/openapi.go:46-57` supplies the central ≥500 scrubber `installServerErrorScrubber`. The merge: the override (`Install`) must do BOTH — build a `*Detail` (br-sfn) AND scrub ≥500 centrally (underwriter). br-sfn's `newProblemError` does NOT scrub 5xx today; the promoted version MUST.
+
+**Implementation vision:** New package `problem` (package name `problem`). Files: `problem.go` (`Detail`, `BaseURI`), `install.go` (`Install`, unexported `newError` override), `maperror.go` (`MapError`, unexported `newProblem`). Rename br-sfn symbols to drop stutter: `ProblemDetail`→`Detail`, `ProblemBaseURI`→`BaseURI`, `InstallProblemDetail`→`Install`, `MapDomainError`→`MapError`. The `newError` override (installed over `huma.NewError`): for `status >= http.StatusInternalServerError` return a `*Detail` with `Detail:"internal error"` and NO folded errs; else fold errs[] (skip nil, honor `huma.ErrorDetailer`) and pass msg through. `sync.Once` guard. `MapError` keeps br-sfn semantics verbatim (returns concrete `*Detail`, scrubs 5xx detail, sets Code+Type when code != "").
+
+**Files:**
+- Create: `commons/net/http/problem/problem.go`
+- Create: `commons/net/http/problem/install.go`
+- Create: `commons/net/http/problem/maperror.go`
+- Test: `commons/net/http/problem/problem_test.go`, `install_test.go`, `maperror_test.go` (`//go:build unit`)
+
+**Verification:** `go test -tags=unit ./commons/net/http/problem/... -count=1 -race` — all pass; `go test -tags=unit -cover` ≥80%.
+
+**Done when:** the six "Done when" assertions of Epic 1.1 hold; `golangci-lint run` clean on the package (errorlint, nilnil, gosec).
+
+#### Task 1.1.2: Schema-shape parity test
+
+- [ ] Done
+
+**Context:** br-sfn has `problemdetail_schema_test.go` + `crossrail_parity_test.go` asserting the generated OpenAPI error schema carries `code`. Promote an equivalent so the org-wide shape is locked.
+
+**Implementation vision:** Register a trivial throwaway operation on a Huma API after `problem.Install()`, render `api.OpenAPI()`, assert the error component schema includes the `code` property and the `Detail` shape (status/title/detail/errors/code). Keep it huma-only (no fiber) by using `humatest` or a minimal config — but per the Huma migration memory, prefer the real adapter path; here a schema-only assertion via `huma.OpenAPI()` on a config-built API avoids needing Fiber.
+
+**Files:**
+- Test: `commons/net/http/problem/schema_test.go` (`//go:build unit`)
+
+**Verification:** `go test -tags=unit ./commons/net/http/problem/... -run Schema -count=1`.
+
+**Done when:** the generated error schema exposes `code` as optional; test fails if `Detail` loses the field.
+
+### Epic 1.2: `openapi` package — Fiber binding + spec serving
+
+**Goal:** `commons/net/http/openapi` exposes `Config`, `New`, `DeclareBearerAuth`, `ServeSpec`.
+**Scope:** `commons/net/http/openapi/` (new dir).
+**Dependencies:** go.mod must gain huma + humafiber + (already present) fiber/v2 — sequence with Epic 1.3 or do the go.mod add first.
+**Done when:** unit tests prove (a) `New` suppresses auto-mount (no /openapi or /docs route registered by the wrapper); (b) transformers/hooks cleared (response body serializes without `$schema`); (c) servers populated when supplied; (d) `DeclareBearerAuth` adds the scheme, nil-safe; (e) `ServeSpec` mounts the three routes under prefix, nil-safe on api, skips+logs on render failure.
+**Status:** Pending
+
+#### Task 1.2.1: Author the `openapi` package
+
+- [ ] Done
+
+**Context:** Port br-sfn `shared/openapi/openapi.go` (the richer copy: it already has `New`, `DeclareBearerAuth`, `ServeSpec`, Scalar template, CSP middleware) verbatim-ish. underwriter's `New` is identical minus the serve/bearer helpers, so br-sfn's file is the base. The ONLY behavioral note: `New` applies no error policy — error policy lives entirely in `problem.Install()`, called by the consumer's bootstrap.
+
+**Implementation vision:** New package `openapi`. `openapi.go`: `Config`, `New` (verbatim from br-sfn), `DeclareBearerAuth`, `ServeSpec`, `scalarCSP`/`docsHTMLTemplate`/`scalarCSPMiddleware`/`docsHTML`. Keep the doc comment's "no error policy" contract. Logger param is `libLog.Logger` from lib-observability (already a lib-commons dep). Do NOT import `problem` here (layering: binding must not depend on error model).
+
+**Files:**
+- Create: `commons/net/http/openapi/openapi.go`
+- Test: `commons/net/http/openapi/openapi_test.go` (`//go:build unit`)
+
+**Verification:** `go test -tags=unit ./commons/net/http/openapi/... -count=1 -race`; test through a real `*fiber.App` via `app.Test` (NOT humatest — Huma issue #935).
+
+**Done when:** Epic 1.2 "Done when" assertions hold; lint clean (bodyclose, noctx, gosec on the CDN CSP string).
+
+### Epic 1.3: go.mod, CI scope, release
+
+**Goal:** lib-commons builds with the new deps, passes all gates, lands on develop, cuts a beta.
+**Scope:** `go.mod`, `go.sum`, `.github/workflows/pr-validation.yml` (PR-title scope), CHANGELOG via semantic-release.
+**Dependencies:** Epics 1.1, 1.2 code complete.
+**Done when:** `go mod tidy` adds `huma/v2`, `humafiber` (and fiber/v3 indirect); `make test-unit lint sec vulncheck` green; coverage ≥80%; PR title scope accepted; merged to develop; `v5.6.0-beta.N` tag exists.
+**Status:** Pending
+
+#### Task 1.3.1: go.mod + PR-title scope + verify
+
+- [ ] Done
+
+**Context:** lib-commons root go.mod has fiber/v2 but no huma. PR-title validation (`.github/workflows/pr-validation.yml`) gates scope; `openapi`/`problem`/`net` must be accepted. Coverage gate is 80% unit (`go-combined-analysis.yml`).
+
+**Implementation vision:** `go get github.com/danielgtaylor/huma/v2@v2.38.0` (match the consumers' pinned version to avoid graph skew), `go mod tidy`. Confirm fiber/v3 lands as indirect. Add `openapi` (and/or `problem`/`net`) to the allowed PR scope list if not already present; if `net` is the umbrella scope, title `feat(net): add Huma OpenAPI wrapper + RFC 9457 problem model`. Run the full local gate set. Open PR → develop.
+
+**Files:**
+- Modify: `go.mod`, `go.sum`
+- Modify: `.github/workflows/pr-validation.yml` (only if scope not already allowed)
+
+**Verification:** `make test-unit && make lint && make sec && make vulncheck` all green; `go list -m github.com/gofiber/fiber/v3` shows it as indirect.
+
+**Done when:** PR green on all gates; merged; beta released.
+
+---
+
+## Phase 2 — underwriter adoption
+
+**Milestone:** underwriter serves the same endpoints through the lib-commons wrapper; `internal/shared/adapters/openapi` deleted; CI green.
+
+### Epic 2.1: Swap underwriter onto lib-commons openapi + problem
+
+**Goal:** bootstrap uses `openapi.New`/`ServeSpec`/`DeclareBearerAuth` + `problem.Install`; local wrapper + scrubber removed.
+**Scope:** `internal/bootstrap/` (routes, openapi mount, error handler wiring), `internal/shared/adapters/openapi/` (delete), go.mod.
+**Dependencies:** Phase 1 beta (or local `replace ../lib-commons`).
+**Done when:** the bootstrap spec-serving (Swagger.Enabled gate) routes through `openapi.ServeSpec`; `problem.Install()` runs before operation registration; the deleted package leaves no references; `make test-unit` green; the committed-artifact drift gate + oneOf union guard still pass.
+**Status:** Pending
+
+### Epic 2.2: Reconcile underwriter error-model + drift tests
+
+**Goal:** underwriter's RFC 9457 assertions account for the optional `code` field; spec drift gate regenerates clean.
+**Scope:** bootstrap spec tests (`huma_spec_test.go`, `routes_br_test.go`), any error-shape assertions, committed `docs/openapi/*.yaml`.
+**Dependencies:** Epic 2.1.
+**Done when:** regenerated spec committed; drift gate green; error-shape tests assert title/status/detail (NOT type — Huma omitempty) and tolerate optional `code`.
+**Status:** Pending
+
+---
+
+## Phase 3 — br-sfn adoption (SPB + SPI×4)
+
+**Milestone:** SPB and all SPI binaries serve through the lib-commons wrapper; `shared/openapi` + `shared/humaerr` deleted; CI green across services.
+
+### Epic 3.1: Swap SPB onto lib-commons
+
+**Goal:** SPB bootstrap/server uses `openapi.*` + `problem.Install`; SPB's `codeOf`/`statusOf`/`fallbackCode` ("SPB-NNNN" taxonomy) wired into `problem.MapError`.
+**Scope:** `services/spb/internal/adapters/http/` (server, routes, error_handler, huma_operations), `services/spb/go.mod`.
+**Dependencies:** Phase 1 beta (or local replace).
+**Done when:** SPB runtime + spec-gen call `problem.Install()` once; domain errors route through `problem.MapError(err, spbCodeOf, spbStatusOf, "SPB-…")`; `shared/openapi`+`shared/humaerr` references removed for SPB; SPB tests green.
+**Status:** Pending
+
+### Epic 3.2: Swap SPI (4 binaries) onto lib-commons
+
+**Goal:** spi/core/brcode/dict binaries each construct their own `openapi.New` API + call `problem.Install`; SPI's empty-code path preserved (`fallbackCode=""`).
+**Scope:** `services/spi/internal/shared/bootstrap/`, the four `*/app/huma_spec.go`, per-binary `cmd/*/main.go`, `services/spi/go.mod`.
+**Dependencies:** Phase 1 beta (or local replace).
+**Done when:** all four specs regenerate; per-binary `DocsPrefix`/`OpenAPIConfig` preserved; SPI integration suites green (the 4 modified test files in the working tree reconciled).
+**Status:** Pending
+
+### Epic 3.3: Delete br-sfn shared copies + cross-rail parity
+
+**Goal:** `shared/openapi` + `shared/humaerr` removed; the crossrail parity test promoted/retargeted at the lib-commons types.
+**Scope:** `services/*/...` references, `shared/` deletion, parity test relocation.
+**Dependencies:** Epics 3.1, 3.2.
+**Done when:** no `shared/openapi`/`shared/humaerr` imports remain; parity coverage exists against lib-commons `problem.Detail`; full br-sfn CI green.
+**Status:** Pending
+
+---
+
+## Phase 4 — stable release + pin
+
+### Epic 4.1: Promote stable, pin both consumers
+
+**Goal:** lib-commons `v5.6.0` stable; underwriter + br-sfn drop `replace`, pin the stable version.
+**Scope:** lib-commons main release; both consumers' go.mod.
+**Dependencies:** Phases 2 & 3 merged.
+**Done when:** `v5.6.0` on main; both consumers pinned to `v5.6.0` (no replace, no beta); both CIs green on the pinned version.
+**Status:** Pending

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.2
 	github.com/aws/smithy-go v1.27.2
 	github.com/bxcodec/dbresolver/v2 v2.2.1
+	github.com/danielgtaylor/huma/v2 v2.38.0
 	github.com/go-playground/validator/v10 v10.30.3
 	github.com/go-redsync/redsync/v4 v4.16.0
 	github.com/gofiber/fiber/v2 v2.52.13
@@ -83,6 +84,9 @@ require (
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/gofiber/fiber/v3 v3.2.0 // indirect
+	github.com/gofiber/schema v1.7.1 // indirect
+	github.com/gofiber/utils/v2 v2.0.4 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
@@ -111,10 +115,12 @@ require (
 	github.com/moby/term v0.5.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.4 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/tinylib/msgp v1.6.4 // indirect
 	github.com/tklauser/go-sysconf v0.4.0 // indirect
 	github.com/tklauser/numcpus v0.12.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GK
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/danielgtaylor/huma/v2 v2.38.0 h1:fb0WZCatnaiHLphMQDDWDjygNxfMkX/ENma3QsRl7vY=
+github.com/danielgtaylor/huma/v2 v2.38.0/go.mod h1:k9hwjlgWFt1t2jsmQGlsgXAG2FBTZa4kkjV581qAtfo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -84,6 +86,8 @@ github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMD
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=
+github.com/fxamacker/cbor/v2 v2.9.1/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -112,6 +116,12 @@ github.com/go-redsync/redsync/v4 v4.16.0 h1:bNcOzeHH9d3s6pghU9NJFMPrQa41f5Nx3L4Y
 github.com/go-redsync/redsync/v4 v4.16.0/go.mod h1:V4gagqgyASWBZuwx4xGzu72aZNb/6Mo05byUa3mVmKQ=
 github.com/gofiber/fiber/v2 v2.52.13 h1:TOKP64iqC9b5P49VrBW5tHhUOvDyrtJ0xePEfzJbCbk=
 github.com/gofiber/fiber/v2 v2.52.13/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
+github.com/gofiber/fiber/v3 v3.2.0 h1:g9+09D320foINPpCnR3ibQ5oBEFHjAWRRfDG1te54u8=
+github.com/gofiber/fiber/v3 v3.2.0/go.mod h1:FHOsc2Db7HhHpsE62QAaJlXVV1pNkbZEptZ4jtti7m4=
+github.com/gofiber/schema v1.7.1 h1:oSJBKdgP8JeIME4TQSAqlNKTU2iBB+2RNmKi8Nsc+TI=
+github.com/gofiber/schema v1.7.1/go.mod h1:A/X5Ffyru4p9eBdp99qu+nzviHzQiZ7odLT+TwxWhbk=
+github.com/gofiber/utils/v2 v2.0.4 h1:WwAxUA7L4MW2DjdEHF234lfqvBqd2vYYuBtA9TJq2ec=
+github.com/gofiber/utils/v2 v2.0.4/go.mod h1:GGERKU3Vhj5z6hS8YKvxL99A54DjOvTFZ0cjZnG4Lj4=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang-migrate/migrate/v4 v4.19.1 h1:OCyb44lFuQfYXYLx1SCxPZQGU7mcaZ7gH9yH4jSFbBA=
@@ -152,8 +162,8 @@ github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwA
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
-github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
-github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
+github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
+github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -198,6 +208,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
+github.com/philhofer/fwd v1.2.0/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
@@ -217,6 +229,8 @@ github.com/redis/rueidis/rueidiscompat v1.0.71 h1:wNZ//kEjMZgBM0KCk7ncOX8KmAgROU
 github.com/redis/rueidis/rueidiscompat v1.0.71/go.mod h1:esmCLJvaRzZoKlgB82G1bY7Iky5TnO9Rz+NlhbEccFI=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/shamaton/msgpack/v3 v3.1.0 h1:jsk0vEAqVvvS9+fTZ5/EcQ9tz860c9pWxJ4Iwecz8gU=
+github.com/shamaton/msgpack/v3 v3.1.0/go.mod h1:DcQG8jrdrQCIxr3HlMYkiXdMhK+KfN2CitkyzsQV4uc=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil/v4 v4.26.4 h1:B4SXVbcwTyrocPHEmWBC4uCYr4Xcu3MK1TXqbprAOWY=
@@ -246,6 +260,8 @@ github.com/testcontainers/testcontainers-go/modules/rabbitmq v0.42.0 h1:Psvaug2W
 github.com/testcontainers/testcontainers-go/modules/rabbitmq v0.42.0/go.mod h1:IKlOzL4xsGYvVT3IS/S6yfhSvNXBvUobQcdmHEJxNZs=
 github.com/testcontainers/testcontainers-go/modules/redis v0.42.0 h1:id/6LH8ZeDrtAUVSuNvZUAJ1kVpb82y1pr9yweAWsRg=
 github.com/testcontainers/testcontainers-go/modules/redis v0.42.0/go.mod h1:uF0jI8FITagQpBNOgweGBmPf6rP4K0SeL1XFPbsZSSY=
+github.com/tinylib/msgp v1.6.4 h1:mOwYbyYDLPj35mkA2BjjYejgJk9BuHxDdvRnb6v2ZcQ=
+github.com/tinylib/msgp v1.6.4/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.4.0 h1:7H0uAN+7RkwWRaxhYXDLqa5V3LPrJeV8wmD9dRUgPQU=
 github.com/tklauser/go-sysconf v0.4.0/go.mod h1:8mTNWyog7H+MpKijp4VmKJAd2bbYQ2zuUwkYRbUArPI=
 github.com/tklauser/numcpus v0.12.0 h1:NR85qdvHA9pFse3x3weVZ0r0ST8R6l5RHbZrlRaqob4=
@@ -254,14 +270,16 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.71.0 h1:tepR7H+Guh9VUqxxcPggYi8R3lGUu2Rsdh+z7/FCY3k=
 github.com/valyala/fasthttp v1.71.0/go.mod h1:z1sDUvOShhXq/C9mwH/fSm1Vb71tUJwmQdgkBrBNwnA=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.2.0 h1:bYKF2AEwG5rqd1BumT4gAnvwU/M9nBp2pTSxeZw7Wvs=
 github.com/xdg-go/scram v1.2.0/go.mod h1:3dlrS0iBaWKYVt2ZfA4cj48umJZ+cAEbR6/SjLA88I8=
 github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
 github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
-github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
-github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
+github.com/xyproto/randomstring v1.2.0 h1:y7PXAEBM3XlwJjPG2JQg4voxBYZ4+hPgRdGKCfU8wik=
+github.com/xyproto/randomstring v1.2.0/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=


### PR DESCRIPTION
## What

Phase 1 of promoting the Huma v2 + OpenAPI 3.1 wrapper into lib-commons as the **org-wide HTTP/OpenAPI layer** (every Lerian service will adopt it, replacing per-repo copies). Two new packages under `commons/net/http`:

- **`openapi`** (fiber/v2 + humafiber binding): `Config`, `New` (metadata, strips the SchemaLinkTransformer `$schema` leak, suppresses Huma auto-mount), `DeclareBearerAuth`, `ServeSpec` (Scalar docs, snapshot-once, caller-gated on Swagger.Enabled).
- **`problem`** (huma-only, no fiber): `Detail` (`huma.ErrorModel` + optional `Code`), `Install` (process-global `huma.NewError` override), `MapError` (generic domain mapper), `BaseURI`.

## Why this shape

The merged wrapper is the **superset** of two existing copies (underwriter + br-sfn):
- br-sfn's richer surface: `DeclareBearerAuth`, `ServeSpec`, coded `Detail`, `MapError`.
- underwriter's safer central scrub: `Install` scrubs every `>=500` body to a static `"internal error"` with no folded errs — closing the direct `huma.Error5xx(rawErr)` info-leak the br-sfn override left open — while `<500` keeps Huma's native field `errors[]`. `Code` is `omitempty`, so code-less rails emit a bare body.

## Deps

Adds `huma/v2 v2.38.0` (matches current consumers, avoids module-graph skew) and `gofiber/fiber/v3 v3.2.0` **indirect** — humafiber dual-imports both Fiber majors; only the v2 path (`NewV2WithGroup`) compiles into a binary. This is accepted, not a wiring bug.

## Validation

- `problem` 100% / `openapi` 95.7% unit coverage; `-race`; full-repo `golangci-lint` 0 issues.
- **Already validated against a real consumer**: `underwriter` migrated onto these packages via a local `replace` and is fully green (build + unit + the byte-equality spec drift gate), so this is the contract a real service exercises, not a speculative one.

## Sequencing

Plan: `docs/plans/2026-06-13-huma-openapi-wrapper-promotion.md`. After this lands and a `v5.6.0-beta` is cut, underwriter (Phase 2) and br-sfn (Phase 3) pin the beta; `v5.6.0` stable + pin is Phase 4.