### PR TITLE
fix(net): harden Huma OpenAPI wrapper edges (prefix, nil ErrorDetail, status clamp)

### DIFF
--- a/commons/net/http/openapi/openapi.go
+++ b/commons/net/http/openapi/openapi.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
+	"path"
+	"strings"
 
 	libLog "github.com/LerianStudio/lib-observability/log"
 	"github.com/danielgtaylor/huma/v2"
@@ -166,7 +168,12 @@ func ServeSpec(app *fiber.App, api huma.API, logger libLog.Logger, prefix, title
 		return
 	}
 
-	specURL := prefix + "/openapi.json"
+	// Normalize prefix to a leading slash and no trailing slash so a caller
+	// passing "v1" (relative spec URL, broken Scalar link) or "/v1/" (double
+	// slash "/v1//openapi.json") still yields a clean absolute path. path.Join
+	// collapses the join cleanly and yields "/openapi.json" when prefix is "/".
+	prefix = "/" + strings.Trim(prefix, "/")
+	specURL := path.Join(prefix, "openapi.json")
 	docs := docsHTML(title, specURL)
 
 	group := app.Group(prefix)

--- a/commons/net/http/openapi/openapi_test.go
+++ b/commons/net/http/openapi/openapi_test.go
@@ -246,6 +246,57 @@ func TestServeSpec_MountsThreeRoutes(t *testing.T) {
 	})
 }
 
+// TestServeSpec_NormalizesPrefix proves ServeSpec normalizes the prefix once
+// (leading slash, no trailing slash, no double slash) before using it for both
+// the served spec URL and the route group: an un-normalized prefix still mounts
+// at the clean absolute path and the docs HTML carries the absolute spec URL.
+func TestServeSpec_NormalizesPrefix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		prefix   string
+		specPath string // expected normalized openapi.json route + served spec URL
+		docsPath string // expected normalized docs route
+	}{
+		{name: "no leading slash", prefix: "v1", specPath: "/v1/openapi.json", docsPath: "/v1/docs"},
+		{name: "trailing slash", prefix: "/v1/", specPath: "/v1/openapi.json", docsPath: "/v1/docs"},
+		{name: "leading slash already", prefix: "/v1", specPath: "/v1/openapi.json", docsPath: "/v1/docs"},
+		{name: "nested", prefix: "api/v1/spi", specPath: "/api/v1/spi/openapi.json", docsPath: "/api/v1/spi/docs"},
+		{name: "root slash", prefix: "/", specPath: "/openapi.json", docsPath: "/docs"},
+		{name: "empty", prefix: "", specPath: "/openapi.json", docsPath: "/docs"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := fiber.New()
+			api := New(app, app.Group("/"), testConfig())
+			registerEcho(api)
+
+			ServeSpec(app, api, &libLog.NopLogger{}, tc.prefix, "Test Docs")
+
+			status, _ := doReq(t, app, http.MethodGet, tc.specPath)
+			assert.Equalf(t, http.StatusOK, status, "spec must be reachable at normalized path %s", tc.specPath)
+
+			resp, err := app.Test(httptest.NewRequest(http.MethodGet, tc.docsPath, nil))
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+
+			require.Equalf(t, http.StatusOK, resp.StatusCode, "docs must be reachable at %s", tc.docsPath)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			docsHTML := string(body)
+			assert.Containsf(t, docsHTML, tc.specPath, "docs HTML must carry the normalized spec URL %s", tc.specPath)
+			assert.NotContains(t, docsHTML, "//openapi.json", "no double slash in spec URL")
+			assert.NotContains(t, docsHTML, `data-url="openapi.json"`, "spec URL must be absolute, not relative")
+		})
+	}
+}
+
 // TestServeSpec_NilAPI proves nil api mounts nothing and does not panic.
 func TestServeSpec_NilAPI(t *testing.T) {
 	t.Parallel()

--- a/commons/net/http/problem/install.go
+++ b/commons/net/http/problem/install.go
@@ -77,7 +77,12 @@ func newError(status int, msg string, errs ...error) huma.StatusError {
 		}
 
 		if converted, ok := e.(huma.ErrorDetailer); ok {
-			details = append(details, converted.ErrorDetail())
+			// ErrorDetail() may return a nil *huma.ErrorDetail; appending it
+			// would serialize a null entry into errors[]. Skip the nil one.
+			if d := converted.ErrorDetail(); d != nil {
+				details = append(details, d)
+			}
+
 			continue
 		}
 

--- a/commons/net/http/problem/install_test.go
+++ b/commons/net/http/problem/install_test.go
@@ -116,6 +116,46 @@ func TestNewError_HonorsErrorDetailer(t *testing.T) {
 	assert.Equal(t, "body.name", d.Errors[0].Location)
 }
 
+// nilDetailErr is a test error implementing huma.ErrorDetailer whose
+// ErrorDetail() returns a nil *huma.ErrorDetail, exercising the skip-nil guard
+// on the <500 fold path.
+type nilDetailErr struct{}
+
+func (e *nilDetailErr) Error() string                  { return "nil detail" }
+func (e *nilDetailErr) ErrorDetail() *huma.ErrorDetail { return nil }
+
+// TestNewError_SkipsNilErrorDetail proves an ErrorDetailer returning a nil
+// *huma.ErrorDetail is skipped (no null entry in Errors[]) while a valid sibling
+// is still folded.
+func TestNewError_SkipsNilErrorDetail(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil detail interspersed with a valid sibling", func(t *testing.T) {
+		t.Parallel()
+
+		carried := &huma.ErrorDetail{Message: "kept"}
+		d := asDetail(t, newError(
+			http.StatusBadRequest,
+			"msg",
+			&nilDetailErr{},
+			&detailErr{d: carried},
+		))
+
+		require.Len(t, d.Errors, 1, "nil ErrorDetail must be skipped, valid sibling kept")
+		for _, e := range d.Errors {
+			assert.NotNil(t, e, "no null entry must be folded into Errors[]")
+		}
+		assert.Same(t, carried, d.Errors[0])
+	})
+
+	t.Run("only a nil-detail error yields nil Errors", func(t *testing.T) {
+		t.Parallel()
+
+		d := asDetail(t, newError(http.StatusBadRequest, "msg", &nilDetailErr{}))
+		assert.Nil(t, d.Errors, "a sole nil ErrorDetail leaves Errors nil, not [null]")
+	})
+}
+
 // TestInstall_OverridesGlobal_Idempotent proves Install swaps the process-global
 // huma.NewError to our *Detail-producing override and that a second call is a
 // safe no-op. It restores the global afterward to avoid leaking across packages.

--- a/commons/net/http/problem/maperror.go
+++ b/commons/net/http/problem/maperror.go
@@ -47,6 +47,14 @@ func MapError(
 	}
 
 	status := statusOf(code)
+	// A recognized domain error must map to a 4xx/5xx. A status below 400 (0,
+	// 2xx, 3xx) means the rail's code->status table is misconfigured — a server
+	// bug, not a client success — so clamp it to 500 rather than emit a
+	// malformed or success-looking problem. The >=500 sanitization below then
+	// applies to the clamped status.
+	if status < http.StatusBadRequest {
+		status = http.StatusInternalServerError
+	}
 
 	detail := msg
 	if status >= http.StatusInternalServerError {

--- a/commons/net/http/problem/maperror_test.go
+++ b/commons/net/http/problem/maperror_test.go
@@ -110,6 +110,30 @@ func TestMapError_Coded_EmptyCode_BareBody(t *testing.T) {
 	assert.Empty(t, d.Type)
 }
 
+// TestMapError_InvalidStatusClamped500 proves a misconfigured statusOf returning
+// a non-error status (0, 2xx, 3xx) for a recognized code is clamped up to a
+// sanitized 500 instead of emitting a malformed or success-looking problem; the
+// domain Code/Type are still carried so clients can branch.
+func TestMapError_InvalidStatusClamped500(t *testing.T) {
+	t.Parallel()
+
+	for _, badStatus := range []int{0, http.StatusOK, http.StatusFound} {
+		t.Run(http.StatusText(badStatus), func(t *testing.T) {
+			t.Parallel()
+
+			codeOf := func(error) (string, string, bool) { return "SPB-3002", "leaky raw cause", true }
+			statusOf := func(string) int { return badStatus }
+
+			d := mapErrDetail(t, MapError(errors.New("domain"), codeOf, statusOf, "SPB-0000"))
+
+			assert.Equal(t, http.StatusInternalServerError, d.Status, "invalid status must clamp to 500")
+			assert.Equal(t, genericServerErrorDetail, d.Detail, "clamped 500 detail must be sanitized")
+			assert.Equal(t, "SPB-3002", d.Code, "domain code still carried on clamped 500")
+			assert.Equal(t, BaseURI+"/SPB-3002", d.Type)
+		})
+	}
+}
+
 // TestMapError_NilCallbacks_SanitizedFallback500 proves a miswired caller passing
 // a nil codeOf or statusOf gets the canonical sanitized 500 (carrying the
 // fallbackCode) instead of a panic.


### PR DESCRIPTION
Three low-severity hardening guards on the shared `commons/net/http/{openapi,problem}` wrapper, surfaced by CodeRabbit on the v5.6.0 promotion PR (#513). Landing them on `develop` first so they ride the `v5.6.0` stable cut — the highest-leverage moment to harden a primitive before every service pins it.

All three are **edge-input only** — no current consumer (underwriter, br-sfn) hits them, and there is **no behavior change for well-formed callers**.

- **`openapi.ServeSpec`** — normalize `prefix` (leading slash, no trailing) so a caller passing `"v1"` (relative spec URL → broken Scalar link) or `"/v1/"` (double slash) still yields a clean absolute path. No-op for `"/v1"` / `"/api/v1/spi"`.
- **`problem.newError`** — skip a `nil *huma.ErrorDetail` returned by an `ErrorDetailer` instead of appending it (was a possible `null` entry in `errors[]`; this also makes us safer than stock `huma.NewError`).
- **`problem.MapError`** — clamp a `statusOf` result `< 400` up to `500`: a recognized domain error mapping to `0/2xx/3xx` means the rail's table is misconfigured (server bug), not a client success.

Tests added per fix. `openapi` 95.9% / `problem` 100% coverage, `-race` green, gofmt/vet/golangci-lint clean.