### PR TITLE
fix(net): genericize shared error-code example

### DIFF
--- a/commons/net/http/openapi/openapi_test.go
+++ b/commons/net/http/openapi/openapi_test.go
@@ -389,7 +389,7 @@ func TestSchemaParity_ErrorSchemaCarriesCode(t *testing.T) {
 	// Belt-and-suspenders: the marshaled spec contains the example domain code.
 	raw, err := json.Marshal(api.OpenAPI())
 	require.NoError(t, err)
-	assert.Contains(t, string(raw), "SPB-3002", "code property example should be present in the spec")
+	assert.Contains(t, string(raw), "ERR-0001", "code property example should be present in the spec")
 }
 
 // findErrorSchema locates the registered component schema that carries the

--- a/commons/net/http/problem/problem.go
+++ b/commons/net/http/problem/problem.go
@@ -36,5 +36,5 @@ const BaseURI = "https://errors.lerian.studio/v1"
 // is dropped by omitempty for code-less rails.
 type Detail struct {
 	huma.ErrorModel
-	Code string `json:"code,omitempty" doc:"Stable domain error code, e.g. SPB-3002" example:"SPB-3002"`
+	Code string `json:"code,omitempty" doc:"Stable, machine-readable domain error code scoped to the emitting service (format: <SERVICE>-NNNN)." example:"ERR-0001"`
 }

--- a/commons/net/http/problem/problem.go
+++ b/commons/net/http/problem/problem.go
@@ -19,7 +19,7 @@ import "github.com/danielgtaylor/huma/v2"
 
 // BaseURI is the single source of truth for the RFC 9457 `type` URI shape. The
 // full `type` for a coded error is BaseURI + "/" + code (flat + versioned),
-// e.g. https://errors.lerian.studio/v1/SPB-3002. The /v1 segment versions the
+// e.g. https://errors.lerian.studio/v1/ERR-0001. The /v1 segment versions the
 // published error catalog so a `type` URI stays a stable, dereferenceable
 // identifier even if the catalog's meaning model later evolves. Never hardcode
 // the literal a second time; reference this constant.


### PR DESCRIPTION
## What

The shared RFC 9457 `problem.Detail.Code` field hardcoded `example:"SPB-3002"` and a `doc:` referencing the SPB namespace (`commons/net/http/problem/problem.go:39`).

Because `problem.Install()` registers `Detail` as the process-global Huma error override, that example is reflected into the OpenAPI error schema of **every** consuming service. In practice it bleeds the SPB rail's namespace into specs where it is wrong — e.g. all four br-sfn SPI specs, whose domain codes are `SPI-XXXX`, not `SPB-XXXX`.

## Change

- `example:"SPB-3002"` → `example:"ERR-0001"` (namespace-neutral placeholder)
- `doc:` → generic: "Stable, machine-readable domain error code scoped to the emitting service (format: `<SERVICE>-NNNN`)."

## Why it's safe

- Behavior is unchanged. The mapping/round-trip tests (`maperror_test.go`, `problem_test.go`) construct `Detail{Code:"SPB-3002"}` explicitly and assert round-trip — they exercise the mapping, not the schema example — and still pass (`go test -tags=unit ./commons/net/http/problem/...` green). Only the generated schema example/description shift.
- No struct/field/type/json change; one tag line.

## Downstream

Once released, the consuming services (underwriter, br-sfn) pick this up on their next lib-commons bump + spec regen; the SPI specs stop advertising `SPB-3002`. Surfaced during the br-sfn OpenAPI quality uplift.