### PR TITLE
fix: promote develop to main (genericize shared error-code example)

### DIFF
--- a/commons/net/http/openapi/openapi_test.go
+++ b/commons/net/http/openapi/openapi_test.go
@@ -389,7 +389,7 @@ func TestSchemaParity_ErrorSchemaCarriesCode(t *testing.T) {
 	// Belt-and-suspenders: the marshaled spec contains the example domain code.
 	raw, err := json.Marshal(api.OpenAPI())
 	require.NoError(t, err)
-	assert.Contains(t, string(raw), "SPB-3002", "code property example should be present in the spec")
+	assert.Contains(t, string(raw), "ERR-0001", "code property example should be present in the spec")
 }
 
 // findErrorSchema locates the registered component schema that carries the

--- a/commons/net/http/problem/problem.go
+++ b/commons/net/http/problem/problem.go
@@ -19,7 +19,7 @@ import "github.com/danielgtaylor/huma/v2"
 
 // BaseURI is the single source of truth for the RFC 9457 `type` URI shape. The
 // full `type` for a coded error is BaseURI + "/" + code (flat + versioned),
-// e.g. https://errors.lerian.studio/v1/SPB-3002. The /v1 segment versions the
+// e.g. https://errors.lerian.studio/v1/ERR-0001. The /v1 segment versions the
 // published error catalog so a `type` URI stays a stable, dereferenceable
 // identifier even if the catalog's meaning model later evolves. Never hardcode
 // the literal a second time; reference this constant.
@@ -36,5 +36,5 @@ const BaseURI = "https://errors.lerian.studio/v1"
 // is dropped by omitempty for code-less rails.
 type Detail struct {
 	huma.ErrorModel
-	Code string `json:"code,omitempty" doc:"Stable domain error code, e.g. SPB-3002" example:"SPB-3002"`
+	Code string `json:"code,omitempty" doc:"Stable, machine-readable domain error code scoped to the emitting service (format: <SERVICE>-NNNN)." example:"ERR-0001"`
 }


### PR DESCRIPTION
Promotes `develop` to `main` to cut a stable release carrying the genericized shared RFC 9457 error-code example.

## Contents (delta vs v5.6.0)
- `fix(net): genericize shared error-code example` (#515) — `problem.Detail.Code` example `SPB-3002` → `ERR-0001`, so the shared error model no longer bleeds a specific rail's code namespace into every consumer's generated spec. Schema-parity test + BaseURI doc comment updated to match.
- changelog/backmerge chores (no code).

## Why now
Unblocks the underwriter + br-sfn pin bump: they currently pin `v5.6.0` (old `SPB-3002` example); a stable `v5.6.1` lets them adopt the fix without pinning a pre-release (the shared security-scan gate reds pre-release pins).

Semantic-release will cut stable `v5.6.1` on merge.