### PR TITLE
feat(tenant-manager): add GetTenantMetadata client method

### DIFF
--- a/commons/tenant-manager/client/client.go
+++ b/commons/tenant-manager/client/client.go
@@ -435,9 +435,11 @@ func (c *Client) cacheTenantConfig(ctx context.Context, cacheKey string, config 
 // The API endpoint is: GET {baseURL}/v1/tenants/{tenantID}/associations/{service}/connections.
 // Successful responses are cached unless WithSkipCache is used.
 func (c *Client) GetTenantConfig(ctx context.Context, tenantID, service string, opts ...GetConfigOption) (*core.TenantConfig, error) {
-	if c.httpClient == nil {
-		c.httpClientOnce.Do(func() { c.httpClient = newDefaultHTTPClient() })
-	}
+	c.httpClientOnce.Do(func() {
+		if c.httpClient == nil {
+			c.httpClient = newDefaultHTTPClient()
+		}
+	})
 
 	logger, tracer, _, _ := observability.NewTrackingFromContext(ctx)
 
@@ -571,9 +573,11 @@ func (c *Client) Close() error {
 // This is used as a fallback when Redis cache is unavailable.
 // The API endpoint is: GET {baseURL}/v1/tenants/active?service={service}
 func (c *Client) GetActiveTenantsByService(ctx context.Context, service string) ([]*TenantSummary, error) {
-	if c.httpClient == nil {
-		c.httpClientOnce.Do(func() { c.httpClient = newDefaultHTTPClient() })
-	}
+	c.httpClientOnce.Do(func() {
+		if c.httpClient == nil {
+			c.httpClient = newDefaultHTTPClient()
+		}
+	})
 
 	logger, tracer, _, _ := observability.NewTrackingFromContext(ctx)
 

--- a/commons/tenant-manager/client/metadata.go
+++ b/commons/tenant-manager/client/metadata.go
@@ -25,9 +25,11 @@ import (
 // mirror GetTenantConfig / GetActiveTenantsByService: only server errors (5xx)
 // trip the circuit breaker; 4xx responses do not.
 func (c *Client) GetTenantMetadata(ctx context.Context, tenantID string) (map[string]string, error) {
-	if c.httpClient == nil {
-		c.httpClientOnce.Do(func() { c.httpClient = newDefaultHTTPClient() })
-	}
+	c.httpClientOnce.Do(func() {
+		if c.httpClient == nil {
+			c.httpClient = newDefaultHTTPClient()
+		}
+	})
 
 	logger, tracer, _, _ := observability.NewTrackingFromContext(ctx)
 

--- a/commons/tenant-manager/client/metadata.go
+++ b/commons/tenant-manager/client/metadata.go
@@ -1,0 +1,124 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	observability "github.com/LerianStudio/lib-observability"
+	libLog "github.com/LerianStudio/lib-observability/log"
+	libOpentelemetry "github.com/LerianStudio/lib-observability/tracing"
+)
+
+// GetTenantMetadata fetches a tenant's free-form metadata map from the Tenant
+// Manager. The API endpoint is: GET {baseURL}/v1/tenants/{tenantID}.
+//
+// The returned map is the tenant's metadata as stored on the tenant entity (it
+// may be nil or empty); callers read only the keys they need. This is distinct
+// from GetTenantConfig, which returns connection configuration from the
+// per-service associations endpoint and does NOT carry tenant metadata.
+//
+// Transport, authentication, circuit-breaker and status-handling semantics
+// mirror GetTenantConfig / GetActiveTenantsByService: only server errors (5xx)
+// trip the circuit breaker; 4xx responses do not.
+func (c *Client) GetTenantMetadata(ctx context.Context, tenantID string) (map[string]string, error) {
+	if c.httpClient == nil {
+		c.httpClientOnce.Do(func() { c.httpClient = newDefaultHTTPClient() })
+	}
+
+	logger, tracer, _, _ := observability.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, "tenantmanager.client.get_tenant_metadata")
+	defer span.End()
+
+	// Check circuit breaker before making the HTTP request.
+	if err := c.checkCircuitBreaker(); err != nil {
+		logger.Log(ctx, libLog.LevelWarn, "circuit breaker open, failing fast", libLog.String("tenant_id", tenantID))
+		libOpentelemetry.HandleSpanBusinessErrorEvent(span, "Circuit breaker open", err)
+
+		return nil, err
+	}
+
+	// Build the URL with a properly escaped path segment to prevent injection.
+	requestURL := fmt.Sprintf("%s/v1/tenants/%s", c.baseURL, url.PathEscape(tenantID))
+
+	logger.Log(ctx, libLog.LevelInfo, "fetching tenant metadata", libLog.String("tenant_id", tenantID))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		logger.Log(ctx, libLog.LevelError, "failed to create request", libLog.Err(err))
+		libOpentelemetry.HandleSpanError(span, "Failed to create HTTP request", err)
+
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	if c.serviceAPIKey != "" {
+		req.Header.Set("X-API-Key", c.serviceAPIKey)
+	}
+
+	// Inject trace context into outgoing HTTP headers for distributed tracing.
+	libOpentelemetry.InjectHTTPContext(ctx, req.Header)
+
+	// #nosec G704 -- baseURL is validated at construction time and not user-controlled
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		c.recordFailure()
+		logger.Log(ctx, libLog.LevelError, "failed to execute request", libLog.Err(err))
+		libOpentelemetry.HandleSpanError(span, "HTTP request failed", err)
+
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body with size limit to prevent unbounded memory allocation.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
+	if err != nil {
+		c.recordFailure()
+		logger.Log(ctx, libLog.LevelError, "failed to read response body", libLog.Err(err))
+		libOpentelemetry.HandleSpanError(span, "Failed to read response body", err)
+
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Only record failure for server errors (5xx), not client errors (4xx).
+		if isServerError(resp.StatusCode) {
+			c.recordFailure()
+		}
+
+		logger.Log(ctx, libLog.LevelError, "tenant manager returned error",
+			libLog.Int("status", resp.StatusCode),
+			libLog.String("body", truncateBody(body, 512)),
+		)
+		libOpentelemetry.HandleSpanError(span, "Tenant Manager returned error", fmt.Errorf("status %d", resp.StatusCode))
+
+		return nil, fmt.Errorf("tenant manager returned status %d for tenant %s", resp.StatusCode, tenantID)
+	}
+
+	// Parse only the metadata field; the tenant entity carries other fields the
+	// caller does not need here.
+	var parsed struct {
+		Metadata map[string]string `json:"metadata"`
+	}
+
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		logger.Log(ctx, libLog.LevelError, "failed to parse response", libLog.Err(err))
+		libOpentelemetry.HandleSpanError(span, "Failed to parse response", err)
+
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	c.recordSuccess()
+	logger.Log(ctx, libLog.LevelInfo, "successfully fetched tenant metadata",
+		libLog.Int("keys", len(parsed.Metadata)),
+		libLog.String("tenant_id", tenantID),
+	)
+
+	return parsed.Metadata, nil
+}

--- a/commons/tenant-manager/client/metadata_test.go
+++ b/commons/tenant-manager/client/metadata_test.go
@@ -7,9 +7,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/core"
 )
 
 func TestClient_GetTenantMetadata_Success(t *testing.T) {
@@ -118,4 +121,50 @@ func TestClient_GetTenantMetadata_APIKeyHeader(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "secret-key", gotAPIKey)
+}
+
+func TestClient_CircuitBreaker_GetTenantMetadata(t *testing.T) {
+	t.Run("server errors (5xx) open the breaker", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+
+		threshold := 2
+		client := mustNewClient(t, server.URL, WithCircuitBreaker(threshold, 30*time.Second))
+		ctx := context.Background()
+
+		for i := 0; i < threshold; i++ {
+			_, err := client.GetTenantMetadata(ctx, "tenant-x")
+			require.Error(t, err)
+		}
+
+		assert.Equal(t, cbOpen, client.cbState)
+
+		// Subsequent call fails fast without hitting the server.
+		_, err := client.GetTenantMetadata(ctx, "tenant-x")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, core.ErrCircuitBreakerOpen)
+	})
+
+	t.Run("client errors (404) do not trip the breaker", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		threshold := 2
+		client := mustNewClient(t, server.URL, WithCircuitBreaker(threshold, 30*time.Second))
+		ctx := context.Background()
+
+		// Exceed the threshold with 404s — the breaker must stay closed.
+		for i := 0; i < threshold+2; i++ {
+			_, err := client.GetTenantMetadata(ctx, "tenant-x")
+			require.Error(t, err)
+			assert.NotErrorIs(t, err, core.ErrCircuitBreakerOpen, "a 404 must not open the breaker")
+		}
+
+		assert.NotEqual(t, cbOpen, client.cbState, "4xx must not open the breaker")
+		assert.Zero(t, client.cbFailures, "4xx must not record breaker failures")
+	})
 }

--- a/commons/tenant-manager/client/metadata_test.go
+++ b/commons/tenant-manager/client/metadata_test.go
@@ -1,0 +1,121 @@
+//go:build unit
+
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_GetTenantMetadata_Success(t *testing.T) {
+	var gotPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "11111111-1111-1111-1111-111111111111",
+			"tenantSlug": "acme",
+			"metadata": {
+				"midaz_org_id": "22222222-2222-2222-2222-222222222222",
+				"payments_ledger_id": "33333333-3333-3333-3333-333333333333"
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := mustNewClient(t, server.URL)
+
+	md, err := client.GetTenantMetadata(context.Background(), "11111111-1111-1111-1111-111111111111")
+
+	require.NoError(t, err)
+	assert.Equal(t, "/v1/tenants/11111111-1111-1111-1111-111111111111", gotPath)
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222", md["midaz_org_id"])
+	assert.Equal(t, "33333333-3333-3333-3333-333333333333", md["payments_ledger_id"])
+}
+
+func TestClient_GetTenantMetadata_NoMetadataField(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"11111111-1111-1111-1111-111111111111","tenantSlug":"acme"}`))
+	}))
+	defer server.Close()
+
+	client := mustNewClient(t, server.URL)
+
+	md, err := client.GetTenantMetadata(context.Background(), "11111111-1111-1111-1111-111111111111")
+
+	require.NoError(t, err)
+	assert.Empty(t, md)
+}
+
+func TestClient_GetTenantMetadata_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"tenant not found"}`))
+	}))
+	defer server.Close()
+
+	client := mustNewClient(t, server.URL)
+
+	md, err := client.GetTenantMetadata(context.Background(), "missing")
+
+	require.Error(t, err)
+	assert.Nil(t, md)
+}
+
+func TestClient_GetTenantMetadata_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client := mustNewClient(t, server.URL)
+
+	md, err := client.GetTenantMetadata(context.Background(), "11111111-1111-1111-1111-111111111111")
+
+	require.Error(t, err)
+	assert.Nil(t, md)
+}
+
+func TestClient_GetTenantMetadata_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{not-json`))
+	}))
+	defer server.Close()
+
+	client := mustNewClient(t, server.URL)
+
+	md, err := client.GetTenantMetadata(context.Background(), "11111111-1111-1111-1111-111111111111")
+
+	require.Error(t, err)
+	assert.Nil(t, md)
+}
+
+func TestClient_GetTenantMetadata_APIKeyHeader(t *testing.T) {
+	var gotAPIKey string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("X-API-Key")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"metadata":{"midaz_org_id":"org"}}`))
+	}))
+	defer server.Close()
+
+	client := mustNewClient(t, server.URL, WithServiceAPIKey("secret-key"))
+
+	_, err := client.GetTenantMetadata(context.Background(), "11111111-1111-1111-1111-111111111111")
+
+	require.NoError(t, err)
+	assert.Equal(t, "secret-key", gotAPIKey)
+}


### PR DESCRIPTION
## What

Adds `Client.GetTenantMetadata(ctx, tenantID) (map[string]string, error)` to the tenant-manager client — returns a tenant's free-form metadata map from `GET /v1/tenants/{tenantID}`.

## Why

`GetTenantConfig` fetches **connection** configuration from the per-service associations endpoint (`/v1/tenants/{id}/associations/{service}/connections`) and does **not** carry the tenant's `metadata`. Consumers that need per-tenant attributes stored on the tenant entity (e.g. a plugin resolving its Midaz `organizationId` / `ledgerId` from `midaz_org_id` / `payments_ledger_id`) currently have no client method to read them. This adds a dedicated, minimal accessor without touching the Tenant Manager service (the `GET /v1/tenants/{id}` endpoint already returns `metadata`).

## Design

- Mirrors the transport/auth/circuit-breaker/status-handling of `GetTenantConfig` and `GetActiveTenantsByService`: lazy HTTP client init, circuit-breaker check, `X-API-Key` when configured, trace-context injection, `io.LimitReader(maxResponseBodySize)`, and **only 5xx trips the breaker** (4xx does not).
- Parses just the `metadata` field; other tenant fields are ignored. Returns nil/empty when the tenant has no metadata.
- New file `commons/tenant-manager/client/metadata.go`; no change to existing types or methods → backward compatible.

## Tests

`commons/tenant-manager/client/metadata_test.go` (httptest, `//go:build unit`): success (asserts path + keys), missing-metadata field, 404, 5xx, invalid JSON, and the `X-API-Key` header.

## Validation

`go build ./commons/tenant-manager/client/...`, `go test -tags=unit ./commons/tenant-manager/client/...`, `gofumpt -l` (clean), and `golangci-lint run ./commons/tenant-manager/client/...` (no issues) — all green.

## Consumer

`plugin-br-payments` will bump to the release containing this and wire `*tmclient.Client` into its multi-tenant org/ledger resolver (currently fail-closed behind an interface).