### PR TITLE
fix(tenant-manager): reset circuit breaker on 4xx round-trips

### DIFF
--- a/commons/tenant-manager/client/client.go
+++ b/commons/tenant-manager/client/client.go
@@ -641,9 +641,13 @@ func (c *Client) GetActiveTenantsByService(ctx context.Context, service string) 
 
 	// Check response status
 	if resp.StatusCode != http.StatusOK {
-		// Only record failure for server errors (5xx), not client errors (4xx)
+		// Server errors (5xx) count as failures; client errors (4xx) are a valid
+		// round-trip and reset the consecutive-failure counter (mirrors
+		// GetTenantConfig's 404/403 handling).
 		if isServerError(resp.StatusCode) {
 			c.recordFailure()
+		} else {
+			c.recordSuccess()
 		}
 
 		logger.Log(ctx, libLog.LevelError, "tenant manager returned error",

--- a/commons/tenant-manager/client/metadata.go
+++ b/commons/tenant-manager/client/metadata.go
@@ -89,9 +89,14 @@ func (c *Client) GetTenantMetadata(ctx context.Context, tenantID string) (map[st
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		// Only record failure for server errors (5xx), not client errors (4xx).
+		// Server errors (5xx) count as failures; client errors (4xx) are a valid
+		// round-trip and reset the consecutive-failure counter (mirrors
+		// GetTenantConfig's 404/403 handling) so a lingering 5xx can't open the
+		// breaker after a successful exchange.
 		if isServerError(resp.StatusCode) {
 			c.recordFailure()
+		} else {
+			c.recordSuccess()
 		}
 
 		logger.Log(ctx, libLog.LevelError, "tenant manager returned error",

--- a/commons/tenant-manager/client/metadata_test.go
+++ b/commons/tenant-manager/client/metadata_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -166,5 +167,29 @@ func TestClient_CircuitBreaker_GetTenantMetadata(t *testing.T) {
 
 		assert.NotEqual(t, cbOpen, client.cbState, "4xx must not open the breaker")
 		assert.Zero(t, client.cbFailures, "4xx must not record breaker failures")
+	})
+
+	t.Run("a 4xx round-trip resets failures recorded by a prior 5xx", func(t *testing.T) {
+		var calls int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if atomic.AddInt32(&calls, 1) == 1 {
+				w.WriteHeader(http.StatusServiceUnavailable) // first call: 5xx
+				return
+			}
+			w.WriteHeader(http.StatusNotFound) // later calls: 4xx
+		}))
+		defer server.Close()
+
+		client := mustNewClient(t, server.URL, WithCircuitBreaker(3, 30*time.Second))
+		ctx := context.Background()
+
+		_, err := client.GetTenantMetadata(ctx, "tenant-x") // 5xx → failure recorded
+		require.Error(t, err)
+		require.Positive(t, client.cbFailures, "5xx must record a failure")
+
+		_, err = client.GetTenantMetadata(ctx, "tenant-x") // 4xx → resets the counter
+		require.Error(t, err)
+		assert.Zero(t, client.cbFailures, "a 4xx valid round-trip must reset consecutive failures")
+		assert.NotEqual(t, cbOpen, client.cbState)
 	})
 }


### PR DESCRIPTION
## What

On a non-2xx response, the tenant-manager client only recorded a failure for 5xx and did **nothing** for 4xx. A prior 5xx therefore stayed counted in `cbFailures`, so a later 5xx could open the circuit breaker even after a successful service round-trip in between (e.g. a 404 business "not found").

Fix: on a non-5xx error status, call `recordSuccess()` to reset the consecutive-failure counter — mirroring `GetTenantConfig`, which already `recordSuccess()` on 404/403. Applied to both `GetTenantMetadata` and `GetActiveTenantsByService`, which shared the same gap.

## Why a separate PR

This addresses a CodeRabbit finding raised on the develop→main release PR #518 (on `GetTenantMetadata`, added in #519). Per the branch policy, the fix lands on `develop` via this PR rather than editing the release PR directly; #518 (head = `develop`) picks it up automatically.

## Tests

Added a reset regression in `TestClient_CircuitBreaker_GetTenantMetadata`: a 5xx records a failure, and a following 4xx clears `cbFailures` (breaker stays closed). The existing 5xx-opens / 404-doesn't-trip cases remain.

## Validation

`go build`, `go test -tags=unit -race`, `golangci-lint` (0 issues), `gofumpt` — all green.