### PR TITLE
fix(net/http): log /health and /readyz probes at debug level

### DIFF
--- a/commons/net/http/withLogging_middleware.go
+++ b/commons/net/http/withLogging_middleware.go
@@ -1,0 +1,73 @@
+package http
+
+import (
+	"strings"
+
+	commons "github.com/LerianStudio/lib-commons/v5/commons"
+	cn "github.com/LerianStudio/lib-commons/v5/commons/constants"
+	observability "github.com/LerianStudio/lib-observability"
+	obsLog "github.com/LerianStudio/lib-observability/log"
+	obsMiddleware "github.com/LerianStudio/lib-observability/middleware"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+// LogMiddlewareOption, WithCustomLogger, and WithObfuscationDisabled are re-exported
+// from lib-observability/middleware so callers using this package don't need to change imports.
+type LogMiddlewareOption = obsMiddleware.LogMiddlewareOption
+
+var (
+	WithCustomLogger    = obsMiddleware.WithCustomLogger
+	WithObfuscationDisabled = obsMiddleware.WithObfuscationDisabled
+)
+
+// probeRoutes are logged at DEBUG level to reduce Grafana/Loki noise.
+// Kubernetes liveness/readiness probes and Prometheus scrapes hit these paths
+// every few seconds per pod; INFO would dominate production log aggregators.
+var probeRoutes = map[string]bool{
+	"/health":  true,
+	"/readyz":  true,
+	"/metrics": true,
+}
+
+// WithHTTPLogging logs HTTP access at INFO level.
+// Requests to probe paths (/health, /readyz, /metrics) are logged at DEBUG to
+// avoid noise from Kubernetes probes in production; enable debug logging to
+// inspect probe traffic when needed.
+func WithHTTPLogging(opts ...LogMiddlewareOption) fiber.Handler {
+	inner := obsMiddleware.WithHTTPLogging(opts...)
+
+	return func(c *fiber.Ctx) error {
+		if !probeRoutes[c.Path()] {
+			return inner(c)
+		}
+
+		// Probe route: set correlation ID and log at DEBUG.
+		hid := strings.TrimSpace(c.Get(cn.HeaderID))
+		if commons.IsNilOrEmpty(&hid) {
+			hid = uuid.New().String()
+		}
+
+		c.Request().Header.Set(cn.HeaderID, hid)
+		c.Set(cn.HeaderID, hid)
+		c.Response().Header.Set(cn.HeaderID, hid)
+		c.SetUserContext(observability.ContextWithHeaderID(c.UserContext(), hid))
+
+		info := obsMiddleware.NewRequestInfo(c, false)
+
+		err := c.Next()
+
+		rw := obsMiddleware.ResponseMetricsWrapper{
+			Context:    c,
+			StatusCode: c.Response().StatusCode(),
+			Size:       len(c.Response().Body()),
+		}
+
+		info.FinishRequestInfo(&rw)
+
+		observability.NewLoggerFromContext(c.UserContext()).
+			Log(c.UserContext(), obsLog.LevelDebug, info.CLFString())
+
+		return err
+	}
+}


### PR DESCRIPTION
## Summary

- Restores `WithHTTPLogging` middleware to `commons/net/http` (was removed when logging moved to `lib-observability`)
- `/health`, `/readyz`, and `/metrics` are now logged at **DEBUG** level instead of INFO (previously `/health` was skipped entirely, `/readyz` was logged at INFO)
- All other paths continue to log at INFO — no change in normal request behaviour

## Motivation

Kubernetes liveness/readiness probes hit `/health` and `/readyz` every few seconds per pod. These requests were being emitted as INFO-level access logs, creating significant noise in Grafana/Loki dashboards and making it harder to find meaningful log entries.

With this change, probe traffic is silent at the default INFO log level and becomes visible by enabling DEBUG logging when inspection is needed.

## Test plan

- [ ] Build passes: `go build ./commons/net/http/...`
- [ ] All existing tests pass: `go test ./commons/net/http/... -tags=unit`
- [ ] Confirm `/health` and `/readyz` requests produce no log output at INFO level
- [ ] Confirm `/health` and `/readyz` requests are visible when `LOG_LEVEL=debug`
- [ ] Confirm regular API requests still log at INFO level (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)