### PR TITLE
feat(s3): conditional Create (IfNoneMatch) for immutable blobs

### DIFF
--- a/commons/tenant-manager/s3/storage.go
+++ b/commons/tenant-manager/s3/storage.go
@@ -9,17 +9,26 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"reflect"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
 // ErrObjectNotFound is returned by Download when the requested object does not
 // exist in the bucket. Callers can match it with errors.Is.
 var ErrObjectNotFound = errors.New("object not found")
+
+// ErrObjectAlreadyExists is returned by Create when the target object already
+// exists. Create uses an S3 conditional write (IfNoneMatch: "*"), so this maps
+// the HTTP 412 / "PreconditionFailed" response into a typed sentinel that
+// callers can match with errors.Is for atomic create-if-absent semantics.
+var ErrObjectAlreadyExists = errors.New("object already exists")
 
 // Storage is a tenant-scoped blob storage abstraction over an S3 bucket.
 //
@@ -33,8 +42,14 @@ var ErrObjectNotFound = errors.New("object not found")
 // All operations resolve the key the same way, so a value written under one
 // tenant context is only visible under that same tenant context.
 type Storage interface {
-	// Upload writes body to the resolved key with the given content type.
+	// Upload writes body to the resolved key with the given content type,
+	// overwriting any existing object at that key.
 	Upload(ctx context.Context, key string, body io.Reader, contentType string) error
+	// Create writes body to the resolved key only if no object already exists
+	// there, using an S3 conditional write (IfNoneMatch: "*"). This is an
+	// atomic create-if-absent with no time-of-check/time-of-use race.
+	// Returns ErrObjectAlreadyExists if the object already exists.
+	Create(ctx context.Context, key string, body io.Reader, contentType string) error
 	// Download returns a reader for the object at the resolved key.
 	// Returns ErrObjectNotFound when the object does not exist.
 	// The caller must close the returned reader.
@@ -111,6 +126,45 @@ func (s *storage) Upload(ctx context.Context, key string, body io.Reader, conten
 
 	if _, err := s.client.PutObject(ctx, input); err != nil {
 		return fmt.Errorf("upload object %q: %w", resolvedKey, err)
+	}
+
+	return nil
+}
+
+// Create writes body to the tenant-resolved key only if the object does not
+// already exist, using the S3 conditional-write header IfNoneMatch: "*".
+//
+// The conditional write is evaluated atomically by S3, so concurrent callers
+// cannot both succeed and there is no time-of-check/time-of-use window. When
+// the object already exists, S3 responds with HTTP 412 / "PreconditionFailed",
+// which is mapped to ErrObjectAlreadyExists.
+func (s *storage) Create(ctx context.Context, key string, body io.Reader, contentType string) error {
+	if body == nil {
+		return errors.New("body must not be nil")
+	}
+
+	resolvedKey, err := GetS3KeyStorageContext(ctx, key)
+	if err != nil {
+		return fmt.Errorf("resolve storage key: %w", err)
+	}
+
+	input := &awss3.PutObjectInput{
+		Bucket:      &s.bucket,
+		Key:         &resolvedKey,
+		Body:        body,
+		IfNoneMatch: aws.String("*"),
+	}
+
+	if contentType != "" {
+		input.ContentType = &contentType
+	}
+
+	if _, err := s.client.PutObject(ctx, input); err != nil {
+		if isAlreadyExists(err) {
+			return fmt.Errorf("%w: %q", ErrObjectAlreadyExists, resolvedKey)
+		}
+
+		return fmt.Errorf("create object %q: %w", resolvedKey, err)
 	}
 
 	return nil
@@ -205,6 +259,30 @@ func isNotFound(err error) bool {
 		case "NoSuchKey", "NotFound":
 			return true
 		}
+	}
+
+	return false
+}
+
+// isAlreadyExists reports whether err represents a failed conditional create,
+// i.e. an object already existing at the target key when IfNoneMatch: "*" was
+// requested. S3 surfaces this as the "PreconditionFailed" API error code,
+// returned with HTTP status 412. It matches the typed API-error code first and
+// falls back to the HTTP status so it stays correct even if the SDK changes how
+// it labels the error code.
+func isAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "PreconditionFailed" {
+		return true
+	}
+
+	var respErr *smithyhttp.ResponseError
+	if errors.As(err, &respErr) && respErr.HTTPStatusCode() == http.StatusPreconditionFailed {
+		return true
 	}
 
 	return false

--- a/commons/tenant-manager/s3/storage_test.go
+++ b/commons/tenant-manager/s3/storage_test.go
@@ -7,12 +7,14 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"testing"
 
 	"github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/core"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,11 +27,12 @@ const testBucket = "test-bucket"
 type fakeObjectAPI struct {
 	objects map[string][]byte
 
-	lastPutKey    string
-	lastGetKey    string
-	lastDeleteKey string
-	lastHeadKey   string
-	lastBucket    string
+	lastPutKey         string
+	lastGetKey         string
+	lastDeleteKey      string
+	lastHeadKey        string
+	lastBucket         string
+	lastPutIfNoneMatch string
 
 	putErr    error
 	getErr    error
@@ -51,9 +54,22 @@ func newFakeObjectAPI() *fakeObjectAPI {
 func (f *fakeObjectAPI) PutObject(_ context.Context, in *awss3.PutObjectInput, _ ...func(*awss3.Options)) (*awss3.PutObjectOutput, error) {
 	f.lastBucket = deref(in.Bucket)
 	f.lastPutKey = deref(in.Key)
+	f.lastPutIfNoneMatch = deref(in.IfNoneMatch)
 
 	if f.putErr != nil {
 		return nil, f.putErr
+	}
+
+	// Emulate S3 conditional write: IfNoneMatch "*" succeeds only when the
+	// object does not already exist; otherwise S3 returns HTTP 412 with the
+	// PreconditionFailed API error code.
+	if deref(in.IfNoneMatch) == "*" {
+		if _, ok := f.objects[deref(in.Key)]; ok {
+			return nil, &smithyhttp.ResponseError{
+				Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusPreconditionFailed}},
+				Err:      &smithy.GenericAPIError{Code: "PreconditionFailed", Message: "At least one of the pre-conditions you specified did not hold"},
+			}
+		}
 	}
 
 	data, err := io.ReadAll(in.Body)
@@ -343,4 +359,113 @@ func TestStorage_Upload_NilBody(t *testing.T) {
 	err = storage.Upload(multiTenantCtx("org_01ABC"), "x.xsd", nil, "application/xml")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "body")
+}
+
+func TestStorage_Create_FreshKey_SetsIfNoneMatchAndStores(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	ctx := multiTenantCtx("org_01ABC")
+	body := []byte("<schema/>")
+
+	err = storage.Create(ctx, "schemas/xsd/foo/v1/schema.xsd", bytes.NewReader(body), "application/xml")
+	require.NoError(t, err)
+
+	// Conditional create must set IfNoneMatch "*" so the write only succeeds
+	// when the object does not already exist.
+	assert.Equal(t, "*", fake.lastPutIfNoneMatch)
+	// The object must be present after a successful create.
+	assert.Equal(t, body, fake.objects["org_01ABC/schemas/xsd/foo/v1/schema.xsd"])
+}
+
+func TestStorage_Create_ExistingKey_ReturnsErrObjectAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	ctx := multiTenantCtx("org_01ABC")
+	original := []byte("original-payload")
+
+	// Seed the object via an unconditional Upload first.
+	require.NoError(t, storage.Upload(ctx, "schemas/x.xsd", bytes.NewReader(original), "application/xml"))
+
+	// A second Create against the same key must fail with the sentinel and
+	// must NOT overwrite the original object.
+	err = storage.Create(ctx, "schemas/x.xsd", bytes.NewReader([]byte("new-payload")), "application/xml")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrObjectAlreadyExists)
+	assert.Equal(t, original, fake.objects["org_01ABC/schemas/x.xsd"])
+}
+
+func TestStorage_Create_AppliesTenantPrefix_MultiTenant(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	ctx := multiTenantCtx("org_01ABC")
+	err = storage.Create(ctx, "schemas/xsd/foo/v1/schema.xsd", bytes.NewReader([]byte("payload")), "application/xml")
+	require.NoError(t, err)
+
+	assert.Equal(t, "org_01ABC/schemas/xsd/foo/v1/schema.xsd", fake.lastPutKey)
+	assert.Equal(t, testBucket, fake.lastBucket)
+}
+
+func TestStorage_Create_BareKey_SingleTenant(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	err = storage.Create(context.Background(), "schemas/xsd/foo/v1/schema.xsd", bytes.NewReader([]byte("payload")), "application/xml")
+	require.NoError(t, err)
+
+	assert.Equal(t, "schemas/xsd/foo/v1/schema.xsd", fake.lastPutKey)
+}
+
+func TestStorage_Create_NilBody(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	err = storage.Create(multiTenantCtx("org_01ABC"), "x.xsd", nil, "application/xml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "body")
+}
+
+func TestStorage_Create_MapsPreconditionFailedAPIError(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	// Simulate a generic smithy APIError carrying the PreconditionFailed code
+	// without an HTTP ResponseError wrapper, exercising the typed-code path.
+	fake.putErr = &smithy.GenericAPIError{Code: "PreconditionFailed", Message: "At least one of the pre-conditions you specified did not hold"}
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	err = storage.Create(multiTenantCtx("org_01ABC"), "x.xsd", bytes.NewReader([]byte("x")), "application/xml")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrObjectAlreadyExists)
+}
+
+func TestStorage_Create_PropagatesUnexpectedError(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	fake.putErr = errors.New("network blip")
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	err = storage.Create(multiTenantCtx("org_01ABC"), "x.xsd", bytes.NewReader([]byte("x")), "application/xml")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrObjectAlreadyExists)
 }


### PR DESCRIPTION
## What

Adds an **atomic conditional-create** to the tenant-scoped S3 blob `Storage` so callers can create-if-absent without a TOCTOU race. `Upload` does an unconditional `PutObject` (overwrites); the new `Create` sets `IfNoneMatch: "*"` so the write succeeds ONLY if the object does not already exist.

```go
Create(ctx context.Context, key string, body io.Reader, contentType string) error
var ErrObjectAlreadyExists = errors.New("object already exists")
```

- 412 / `PreconditionFailed` detected via typed path (`smithy.APIError` code + `*smithyhttp.ResponseError` HTTP 412 fallback) — same style as the existing `isNotFound` helper. No string-matching.
- `Upload` is **byte-for-byte unchanged** (only its doc comment gains a clause contrasting it with `Create`). `Create` is purely additive.
- aws-sdk-go-v2/service/s3 v1.104.0 supports `PutObjectInput.IfNoneMatch`; **go.mod/go.sum unchanged** (both imports were already transitive deps).

## Why

Backs the Flowker Schema Registry manual OpenAPI upload (#2429): native specs are immutable per ADR-P2-8, but an `Exists`-then-`Upload` guard has a TOCTOU window where a concurrent publish (manual + CI) can overwrite an immutable version. `Create` closes that window atomically; the caller maps `ErrObjectAlreadyExists` → 409.

## Tests / gates

- 7 new `Create` tests (fresh→ok + asserts `IfNoneMatch:"*"`; existing→`ErrObjectAlreadyExists`, original unchanged; tenant-prefix + bare-key; nil body; typed 412 path; unexpected-error propagation) on the existing fake harness.
- `go test -tags unit ./commons/tenant-manager/s3/...` PASS, coverage 88.3%; golangci-lint v2.12.2 = 0 issues; gofmt/vet clean.

## Compat note

`Create` is added to the **exported `Storage` interface** — an external type implementing `s3.Storage` by value (not embedding the concrete impl) would need the new method. All in-repo usage goes through `NewStorage` (unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)