### PR TITLE
feat(s3): List object keys by prefix (paginated)

### DIFF
--- a/commons/tenant-manager/s3/storage.go
+++ b/commons/tenant-manager/s3/storage.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/core"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -59,6 +60,16 @@ type Storage interface {
 	Delete(ctx context.Context, key string) error
 	// Exists reports whether an object exists at the resolved key.
 	Exists(ctx context.Context, key string) (bool, error)
+	// List enumerates the LOGICAL keys of every object stored under prefix.
+	//
+	// The prefix is resolved through the same tenant key resolution the other
+	// methods use, so a tenant context lists only that tenant's space and a
+	// global/empty-tenant context lists under the bare prefix. The returned
+	// keys are logical (the tenant prefix is stripped back off), matching the
+	// keys callers passed to Upload/Create. Results are paginated internally,
+	// so a prefix with more objects than one S3 page still returns every key.
+	// Returns an empty (non-nil) slice when nothing matches.
+	List(ctx context.Context, prefix string) ([]string, error)
 }
 
 // objectAPI is the narrow seam over the AWS S3 client used by Storage.
@@ -70,6 +81,7 @@ type objectAPI interface {
 	GetObject(ctx context.Context, params *awss3.GetObjectInput, optFns ...func(*awss3.Options)) (*awss3.GetObjectOutput, error)
 	DeleteObject(ctx context.Context, params *awss3.DeleteObjectInput, optFns ...func(*awss3.Options)) (*awss3.DeleteObjectOutput, error)
 	HeadObject(ctx context.Context, params *awss3.HeadObjectInput, optFns ...func(*awss3.Options)) (*awss3.HeadObjectOutput, error)
+	ListObjectsV2(ctx context.Context, params *awss3.ListObjectsV2Input, optFns ...func(*awss3.Options)) (*awss3.ListObjectsV2Output, error)
 }
 
 // storage is the aws-sdk-go-v2 backed implementation of Storage.
@@ -232,6 +244,71 @@ func (s *storage) Exists(ctx context.Context, key string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// List enumerates the logical keys of every object stored under the
+// tenant-resolved prefix.
+//
+// The prefix is resolved with GetS3KeyStorageContext exactly like every other
+// method, so listing is tenant-scoped: a tenant context only sees that tenant's
+// objects, a global/empty-tenant context lists under the bare prefix. The
+// ListObjectsV2 response is paginated, so this follows the continuation token
+// until IsTruncated is false to collect every matching key. Each physical S3
+// key is converted back to its logical form (tenant prefix stripped) so the
+// values returned match what callers passed to Upload/Create. An empty,
+// non-nil slice is returned when nothing matches.
+func (s *storage) List(ctx context.Context, prefix string) ([]string, error) {
+	resolvedPrefix, err := GetS3KeyStorageContext(ctx, prefix)
+	if err != nil {
+		return nil, fmt.Errorf("resolve storage key: %w", err)
+	}
+
+	tenantID := core.GetTenantIDContext(ctx)
+
+	keys := make([]string, 0)
+
+	var continuationToken *string
+
+	for {
+		out, err := s.client.ListObjectsV2(ctx, &awss3.ListObjectsV2Input{
+			Bucket:            &s.bucket,
+			Prefix:            &resolvedPrefix,
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list objects under prefix %q: %w", resolvedPrefix, err)
+		}
+
+		if out == nil {
+			return nil, fmt.Errorf("list objects under prefix %q: nil response", resolvedPrefix)
+		}
+
+		for i := range out.Contents {
+			obj := out.Contents[i]
+			if obj.Key == nil {
+				continue
+			}
+
+			logicalKey, err := StripObjectStoragePrefix(tenantID, *obj.Key)
+			if err != nil {
+				return nil, fmt.Errorf("strip tenant prefix from key %q: %w", *obj.Key, err)
+			}
+
+			keys = append(keys, logicalKey)
+		}
+
+		if out.IsTruncated == nil || !*out.IsTruncated {
+			break
+		}
+
+		if out.NextContinuationToken == nil {
+			break
+		}
+
+		continuationToken = out.NextContinuationToken
+	}
+
+	return keys, nil
 }
 
 // isNotFound reports whether err represents an S3 "object does not exist"

--- a/commons/tenant-manager/s3/storage.go
+++ b/commons/tenant-manager/s3/storage.go
@@ -253,10 +253,12 @@ func (s *storage) Exists(ctx context.Context, key string) (bool, error) {
 // method, so listing is tenant-scoped: a tenant context only sees that tenant's
 // objects, a global/empty-tenant context lists under the bare prefix. The
 // ListObjectsV2 response is paginated, so this follows the continuation token
-// until IsTruncated is false to collect every matching key. Each physical S3
-// key is converted back to its logical form (tenant prefix stripped) so the
-// values returned match what callers passed to Upload/Create. An empty,
-// non-nil slice is returned when nothing matches.
+// until IsTruncated is false to collect every matching key. If S3 reports a
+// truncated page without a continuation token, this returns an error rather
+// than a silently incomplete result set. Each physical S3 key is converted
+// back to its logical form (tenant prefix stripped) so the values returned
+// match what callers passed to Upload/Create. An empty, non-nil slice is
+// returned when nothing matches.
 func (s *storage) List(ctx context.Context, prefix string) ([]string, error) {
 	resolvedPrefix, err := GetS3KeyStorageContext(ctx, prefix)
 	if err != nil {
@@ -301,8 +303,11 @@ func (s *storage) List(ctx context.Context, prefix string) ([]string, error) {
 			break
 		}
 
-		if out.NextContinuationToken == nil {
-			break
+		// S3 reported more results but gave us no continuation token to fetch
+		// them. Returning here would silently drop the remaining objects, so
+		// fail loudly rather than hand back a partial result set.
+		if out.NextContinuationToken == nil || *out.NextContinuationToken == "" {
+			return nil, fmt.Errorf("list objects under prefix %q: truncated response missing continuation token", prefix)
 		}
 
 		continuationToken = out.NextContinuationToken

--- a/commons/tenant-manager/s3/storage_test.go
+++ b/commons/tenant-manager/s3/storage_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"sort"
@@ -60,8 +61,11 @@ type fakeObjectAPI struct {
 	// exercising the nil-key skip.
 	listKeysWithNil []string
 	// listTruncatedNoToken, when true, returns a page marked truncated but with
-	// no NextContinuationToken, exercising the safety break.
+	// no NextContinuationToken, exercising the error path.
 	listTruncatedNoToken bool
+	// listTruncatedEmptyToken, when true, returns a page marked truncated with a
+	// present-but-empty NextContinuationToken, exercising the same error path.
+	listTruncatedEmptyToken bool
 
 	// getNilOutput, when true, makes GetObject return a nil *GetObjectOutput
 	// with a nil error, simulating a misbehaving custom objectAPI.
@@ -175,6 +179,12 @@ func (f *fakeObjectAPI) ListObjectsV2(_ context.Context, in *awss3.ListObjectsV2
 		return &awss3.ListObjectsV2Output{IsTruncated: aws.Bool(true)}, nil
 	}
 
+	if f.listTruncatedEmptyToken {
+		empty := ""
+
+		return &awss3.ListObjectsV2Output{IsTruncated: aws.Bool(true), NextContinuationToken: &empty}, nil
+	}
+
 	if len(f.listKeysWithNil) > 0 {
 		contents := make([]s3types.Object, 0, len(f.listKeysWithNil))
 
@@ -196,8 +206,21 @@ func (f *fakeObjectAPI) ListObjectsV2(_ context.Context, in *awss3.ListObjectsV2
 	// continuation token to collect all keys.
 	if len(f.listPages) > 0 {
 		idx := 0
+
 		if in.ContinuationToken != nil {
-			idx = pageIndexFromToken(deref(in.ContinuationToken))
+			var err error
+
+			idx, err = pageIndexFromToken(deref(in.ContinuationToken))
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// Fail fast on an out-of-range index instead of panicking or silently
+		// serving page 0, so a malformed/unexpected continuation token is a
+		// visible test failure rather than misleading data.
+		if idx < 0 || idx >= len(f.listPages) {
+			return nil, fmt.Errorf("fake ListObjectsV2: page index %d out of range [0,%d)", idx, len(f.listPages))
 		}
 
 		page := f.listPages[idx]
@@ -238,13 +261,17 @@ func tokenForPageIndex(idx int) string {
 	return "page-" + strconv.Itoa(idx)
 }
 
-func pageIndexFromToken(token string) int {
-	idx, err := strconv.Atoi(strings.TrimPrefix(token, "page-"))
-	if err != nil {
-		return 0
+func pageIndexFromToken(token string) (int, error) {
+	if !strings.HasPrefix(token, "page-") {
+		return 0, fmt.Errorf("fake ListObjectsV2: unexpected continuation token %q", token)
 	}
 
-	return idx
+	idx, err := strconv.Atoi(strings.TrimPrefix(token, "page-"))
+	if err != nil {
+		return 0, fmt.Errorf("fake ListObjectsV2: malformed continuation token %q: %w", token, err)
+	}
+
+	return idx, nil
 }
 
 func deref(s *string) string {
@@ -721,19 +748,38 @@ func TestStorage_List_SkipsNilKeyObjects(t *testing.T) {
 	}, keys)
 }
 
-func TestStorage_List_TruncatedWithoutToken_StopsSafely(t *testing.T) {
+func TestStorage_List_TruncatedWithoutToken_ReturnsError(t *testing.T) {
 	t.Parallel()
 
 	fake := newFakeObjectAPI()
-	// A response marked truncated but missing a continuation token must not loop
-	// forever; the implementation breaks out and returns what it has.
+	// A response marked truncated but missing a continuation token means S3 has
+	// more results it cannot hand back. Returning the partial slice would
+	// silently drop data, so List must surface an error instead.
 	fake.listTruncatedNoToken = true
 	storage, err := NewStorage(fake, testBucket)
 	require.NoError(t, err)
 
 	keys, err := storage.List(multiTenantCtx("org_01ABC"), "schemas/openapi/foo/")
+	require.Error(t, err)
+	assert.Nil(t, keys)
+	assert.Contains(t, err.Error(), "truncated response missing continuation token")
+	// Only the single (truncated) page is fetched; the loop does not continue.
+	assert.Equal(t, 1, fake.listCallCount)
+}
+
+func TestStorage_List_TruncatedWithEmptyToken_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	// An empty (non-nil) continuation token is just as unusable as a nil one;
+	// List must treat it the same way and refuse to return partial data.
+	fake.listTruncatedEmptyToken = true
+	storage, err := NewStorage(fake, testBucket)
 	require.NoError(t, err)
-	assert.NotNil(t, keys)
-	assert.Empty(t, keys)
+
+	keys, err := storage.List(multiTenantCtx("org_01ABC"), "schemas/openapi/foo/")
+	require.Error(t, err)
+	assert.Nil(t, keys)
+	assert.Contains(t, err.Error(), "truncated response missing continuation token")
 	assert.Equal(t, 1, fake.listCallCount)
 }

--- a/commons/tenant-manager/s3/storage_test.go
+++ b/commons/tenant-manager/s3/storage_test.go
@@ -8,9 +8,13 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sort"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/LerianStudio/lib-commons/v5/commons/tenant-manager/core"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
@@ -33,11 +37,31 @@ type fakeObjectAPI struct {
 	lastHeadKey        string
 	lastBucket         string
 	lastPutIfNoneMatch string
+	lastListPrefix     string
 
 	putErr    error
 	getErr    error
 	deleteErr error
 	headErr   error
+	listErr   error
+
+	// listPages, when non-empty, is returned page-by-page by ListObjectsV2
+	// instead of deriving the result from objects. Each entry is one page of
+	// full S3 keys; pages before the last are returned as truncated.
+	listPages [][]string
+	// listCallCount records how many times ListObjectsV2 was invoked, so tests
+	// can assert pagination drove more than one round trip.
+	listCallCount int
+	// listNilOutput, when true, makes ListObjectsV2 return a nil output with a
+	// nil error, simulating a misbehaving custom objectAPI.
+	listNilOutput bool
+	// listKeysWithNil, when non-empty, is returned as a single page whose
+	// Contents includes a nil-Key object (a "" entry marks the nil-Key slot),
+	// exercising the nil-key skip.
+	listKeysWithNil []string
+	// listTruncatedNoToken, when true, returns a page marked truncated but with
+	// no NextContinuationToken, exercising the safety break.
+	listTruncatedNoToken bool
 
 	// getNilOutput, when true, makes GetObject return a nil *GetObjectOutput
 	// with a nil error, simulating a misbehaving custom objectAPI.
@@ -132,6 +156,95 @@ func (f *fakeObjectAPI) HeadObject(_ context.Context, in *awss3.HeadObjectInput,
 	}
 
 	return &awss3.HeadObjectOutput{}, nil
+}
+
+func (f *fakeObjectAPI) ListObjectsV2(_ context.Context, in *awss3.ListObjectsV2Input, _ ...func(*awss3.Options)) (*awss3.ListObjectsV2Output, error) {
+	f.lastBucket = deref(in.Bucket)
+	f.lastListPrefix = deref(in.Prefix)
+	f.listCallCount++
+
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+
+	if f.listNilOutput {
+		return nil, nil //nolint:nilnil // deliberately simulating a misbehaving objectAPI
+	}
+
+	if f.listTruncatedNoToken {
+		return &awss3.ListObjectsV2Output{IsTruncated: aws.Bool(true)}, nil
+	}
+
+	if len(f.listKeysWithNil) > 0 {
+		contents := make([]s3types.Object, 0, len(f.listKeysWithNil))
+
+		for _, k := range f.listKeysWithNil {
+			if k == "" {
+				contents = append(contents, s3types.Object{Key: nil})
+				continue
+			}
+
+			key := k
+			contents = append(contents, s3types.Object{Key: &key})
+		}
+
+		return &awss3.ListObjectsV2Output{Contents: contents}, nil
+	}
+
+	// Scripted multi-page mode: return one page per call, marking every page
+	// but the last as truncated so the implementation must follow the
+	// continuation token to collect all keys.
+	if len(f.listPages) > 0 {
+		idx := 0
+		if in.ContinuationToken != nil {
+			idx = pageIndexFromToken(deref(in.ContinuationToken))
+		}
+
+		page := f.listPages[idx]
+		contents := make([]s3types.Object, 0, len(page))
+
+		for _, k := range page {
+			key := k
+			contents = append(contents, s3types.Object{Key: &key})
+		}
+
+		out := &awss3.ListObjectsV2Output{Contents: contents}
+
+		if idx < len(f.listPages)-1 {
+			next := tokenForPageIndex(idx + 1)
+			out.IsTruncated = aws.Bool(true)
+			out.NextContinuationToken = &next
+		}
+
+		return out, nil
+	}
+
+	// In-memory mode: derive the result from the stored objects, filtering by
+	// the requested prefix.
+	prefix := deref(in.Prefix)
+	contents := make([]s3types.Object, 0, len(f.objects))
+
+	for k := range f.objects {
+		if strings.HasPrefix(k, prefix) {
+			key := k
+			contents = append(contents, s3types.Object{Key: &key})
+		}
+	}
+
+	return &awss3.ListObjectsV2Output{Contents: contents}, nil
+}
+
+func tokenForPageIndex(idx int) string {
+	return "page-" + strconv.Itoa(idx)
+}
+
+func pageIndexFromToken(token string) int {
+	idx, err := strconv.Atoi(strings.TrimPrefix(token, "page-"))
+	if err != nil {
+		return 0
+	}
+
+	return idx
 }
 
 func deref(s *string) string {
@@ -468,4 +581,159 @@ func TestStorage_Create_PropagatesUnexpectedError(t *testing.T) {
 	err = storage.Create(multiTenantCtx("org_01ABC"), "x.xsd", bytes.NewReader([]byte("x")), "application/xml")
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, ErrObjectAlreadyExists)
+}
+
+func TestStorage_List_ReturnsLogicalKeysUnderPrefix_MultiTenant(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	ctx := multiTenantCtx("org_01ABC")
+	require.NoError(t, storage.Upload(ctx, "schemas/openapi/foo/v1/spec.json", bytes.NewReader([]byte("a")), "application/json"))
+	require.NoError(t, storage.Upload(ctx, "schemas/openapi/foo/v2/spec.json", bytes.NewReader([]byte("b")), "application/json"))
+	// An object under a different prefix must NOT be returned.
+	require.NoError(t, storage.Upload(ctx, "schemas/xsd/bar/v1/schema.xsd", bytes.NewReader([]byte("c")), "application/xml"))
+
+	keys, err := storage.List(ctx, "schemas/openapi/foo/")
+	require.NoError(t, err)
+
+	sort.Strings(keys)
+	// Returned keys are LOGICAL (tenant prefix stripped), matching the keys the
+	// caller passed to Upload.
+	assert.Equal(t, []string{
+		"schemas/openapi/foo/v1/spec.json",
+		"schemas/openapi/foo/v2/spec.json",
+	}, keys)
+
+	// The S3 request must carry the tenant-RESOLVED prefix.
+	assert.Equal(t, "org_01ABC/schemas/openapi/foo/", fake.lastListPrefix)
+	assert.Equal(t, testBucket, fake.lastBucket)
+}
+
+func TestStorage_List_BarePrefix_SingleTenant(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, storage.Upload(ctx, "schemas/openapi/foo/v1/spec.json", bytes.NewReader([]byte("a")), "application/json"))
+
+	keys, err := storage.List(ctx, "schemas/openapi/foo/")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"schemas/openapi/foo/v1/spec.json"}, keys)
+	// Global/empty-tenant context lists under the bare prefix (no tenant segment).
+	assert.Equal(t, "schemas/openapi/foo/", fake.lastListPrefix)
+}
+
+func TestStorage_List_PaginatesAcrossTruncatedResponses(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	// Two pages of full (resolved) S3 keys. The first page is truncated, so the
+	// implementation must follow the continuation token to fetch the second.
+	fake.listPages = [][]string{
+		{"org_01ABC/schemas/openapi/foo/v1/spec.json", "org_01ABC/schemas/openapi/foo/v2/spec.json"},
+		{"org_01ABC/schemas/openapi/foo/v3/spec.json"},
+	}
+
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	keys, err := storage.List(multiTenantCtx("org_01ABC"), "schemas/openapi/foo/")
+	require.NoError(t, err)
+
+	sort.Strings(keys)
+	assert.Equal(t, []string{
+		"schemas/openapi/foo/v1/spec.json",
+		"schemas/openapi/foo/v2/spec.json",
+		"schemas/openapi/foo/v3/spec.json",
+	}, keys)
+
+	// Both pages must have been fetched (>= 2 round trips).
+	assert.GreaterOrEqual(t, fake.listCallCount, 2)
+}
+
+func TestStorage_List_EmptyResult_ReturnsEmptySlice(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	keys, err := storage.List(multiTenantCtx("org_01ABC"), "schemas/openapi/none/")
+	require.NoError(t, err)
+	assert.NotNil(t, keys)
+	assert.Empty(t, keys)
+}
+
+func TestStorage_List_PropagatesUnexpectedError(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	fake.listErr = errors.New("network blip")
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	_, err = storage.List(multiTenantCtx("org_01ABC"), "schemas/openapi/foo/")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "network blip")
+}
+
+func TestStorage_List_NilOutput_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	fake.listNilOutput = true
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	_, err = storage.List(multiTenantCtx("org_01ABC"), "schemas/openapi/foo/")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil response")
+}
+
+func TestStorage_List_SkipsNilKeyObjects(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	// The middle entry ("") is returned as an object with a nil Key, which must
+	// be skipped without producing a spurious key.
+	fake.listKeysWithNil = []string{
+		"org_01ABC/schemas/openapi/foo/v1/spec.json",
+		"",
+		"org_01ABC/schemas/openapi/foo/v2/spec.json",
+	}
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	keys, err := storage.List(multiTenantCtx("org_01ABC"), "schemas/openapi/foo/")
+	require.NoError(t, err)
+
+	sort.Strings(keys)
+	assert.Equal(t, []string{
+		"schemas/openapi/foo/v1/spec.json",
+		"schemas/openapi/foo/v2/spec.json",
+	}, keys)
+}
+
+func TestStorage_List_TruncatedWithoutToken_StopsSafely(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeObjectAPI()
+	// A response marked truncated but missing a continuation token must not loop
+	// forever; the implementation breaks out and returns what it has.
+	fake.listTruncatedNoToken = true
+	storage, err := NewStorage(fake, testBucket)
+	require.NoError(t, err)
+
+	keys, err := storage.List(multiTenantCtx("org_01ABC"), "schemas/openapi/foo/")
+	require.NoError(t, err)
+	assert.NotNil(t, keys)
+	assert.Empty(t, keys)
+	assert.Equal(t, 1, fake.listCallCount)
 }


### PR DESCRIPTION
## What

Adds `List(ctx, prefix string) ([]string, error)` to the tenant-scoped S3 blob `Storage` — paginated prefix listing. Resolves the prefix through the same tenant-key path as the other methods (global/empty-tenant ctx → bare prefix), queries `ListObjectsV2` with full pagination (`NextContinuationToken`), and returns **prefix-stripped logical keys** (consistent with how `Upload`/`Download`/`Exists` present keys). Empty → empty non-nil slice; unexpected errors wrapped.

## Why

Backs the Flowker Schema Registry **list-OpenAPI-versions** endpoint (#2386 follow-up): the FE version-pin selector needs to enumerate the versions actually present in S3 under `{env}/schemas/openapi/{service}/`. No List existed; listing was the missing capability.

## Tests / gates
- 8 new `List` cases on the existing fake harness: keys under prefix, pagination across a truncated (≥2-page) response, empty→empty slice, tenant-prefix resolution (global bare + multi-tenant prefixed), asserts the resolved `ListObjectsV2Input.Prefix`.
- `go test -tags=unit ./commons/tenant-manager/s3/...` 60 pass; List coverage 92.3%; golangci v2.12.2 = 0; vet/gofmt clean.
- Existing methods (Upload/Create/Download/Delete/Exists) **byte-for-byte unchanged** — additive only.

## Compat note
`List` is added to the exported `Storage` interface — an external by-value implementer would need the method (all in-repo usage goes through `NewStorage`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)